### PR TITLE
Make it easier and safer to create MultiCalls

### DIFF
--- a/jmap-client/src/main/java/rs/ltt/jmap/client/JmapClient.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/JmapClient.java
@@ -89,7 +89,7 @@ public class JmapClient implements Closeable {
     public ListenableFuture<MethodResponses> call(MethodCall methodCall) {
         Preconditions.checkState(!isShutdown(), "Unable to call method. JmapClient has been closed already");
         final JmapRequest.Builder jmapRequestBuilder = new JmapRequest.Builder();
-        final ListenableFuture<MethodResponses> methodResponsesFuture = jmapRequestBuilder.call(methodCall);
+        final ListenableFuture<MethodResponses> methodResponsesFuture = jmapRequestBuilder.call(methodCall).getMethodResponses();
         this.execute(jmapRequestBuilder.build());
         return methodResponsesFuture;
     }
@@ -139,13 +139,8 @@ public class JmapClient implements Closeable {
 
         }
 
-        public synchronized ListenableFuture<MethodResponses> add(rs.ltt.jmap.common.Request.Invocation invocation) {
-            Preconditions.checkState(!executed,"Unable to add invocation. MultiCall has already been executed");
-            return jmapRequestBuilder.add(invocation);
-        }
-
-        public synchronized ListenableFuture<MethodResponses> call(MethodCall methodCall) {
-            Preconditions.checkState(!executed,"Unable to add MethodCall. MultiCall has already been executed");
+        public synchronized JmapRequest.Call call(MethodCall methodCall) {
+            Preconditions.checkState(!executed, "Unable to add MethodCall. MultiCall has already been executed");
             return jmapRequestBuilder.call(methodCall);
         }
 

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/JmapRequest.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/JmapRequest.java
@@ -58,13 +58,14 @@ public class JmapRequest {
 
         private final Map<Request.Invocation, SettableFuture<MethodResponses>> map = new LinkedHashMap<>();
 
-        public ListenableFuture<MethodResponses> call(final MethodCall methodCall) {
-            return add(Request.Invocation.create(methodCall));
-
+        public Call call(final MethodCall methodCall) {
+            final Request.Invocation invocation = Request.Invocation.create(methodCall);
+            final ListenableFuture<MethodResponses> future = add(invocation);
+            return new Call(future, invocation);
         }
 
         //TODO throw illegal state when adding after build
-        public ListenableFuture<MethodResponses> add(final Request.Invocation invocation) {
+        private ListenableFuture<MethodResponses> add(final Request.Invocation invocation) {
             final SettableFuture<MethodResponses> future = SettableFuture.create();
             this.map.put(invocation, future);
             return future;
@@ -75,4 +76,25 @@ public class JmapRequest {
         }
     }
 
+    public static class Call {
+        private final ListenableFuture<MethodResponses> future;
+        private final Request.Invocation invocation;
+
+        private Call(ListenableFuture<MethodResponses> future, Request.Invocation invocation) {
+            this.future = future;
+            this.invocation = invocation;
+        }
+
+        public ListenableFuture<MethodResponses> getMethodResponses() {
+            return future;
+        }
+
+        public String getMethodCallId() {
+            return invocation.getId();
+        }
+
+        public Request.Invocation.ResultReference createResultReference(String path) {
+            return invocation.createReference(path);
+        }
+    }
 }

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/JmapRequest.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/JmapRequest.java
@@ -57,11 +57,16 @@ public class JmapRequest {
     public static class Builder {
 
         private final Map<Request.Invocation, SettableFuture<MethodResponses>> map = new LinkedHashMap<>();
+        private int nextMethodCallId = 0;
 
         public Call call(final MethodCall methodCall) {
-            final Request.Invocation invocation = Request.Invocation.create(methodCall);
+            final Request.Invocation invocation = Request.Invocation.create(methodCall, nextMethodCallId());
             final ListenableFuture<MethodResponses> future = add(invocation);
             return new Call(future, invocation);
+        }
+
+        private String nextMethodCallId() {
+            return Integer.toString(nextMethodCallId++);
         }
 
         //TODO throw illegal state when adding after build
@@ -87,10 +92,6 @@ public class JmapRequest {
 
         public ListenableFuture<MethodResponses> getMethodResponses() {
             return future;
-        }
-
-        public String getMethodCallId() {
-            return invocation.getId();
         }
 
         public Request.Invocation.ResultReference createResultReference(String path) {

--- a/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
+++ b/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
@@ -25,7 +25,6 @@ import org.junit.Assert;
 import org.junit.Test;
 import rs.ltt.jmap.client.api.MethodErrorResponseException;
 import rs.ltt.jmap.client.api.MethodResponseNotFoundException;
-import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.method.MethodErrorResponse;
 import rs.ltt.jmap.common.method.call.mailbox.GetMailboxMethodCall;
 import rs.ltt.jmap.common.method.error.UnknownMethodMethodErrorResponse;
@@ -61,13 +60,13 @@ public class HttpJmapClientTest {
 
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
 
-        final Request.Invocation invocation = Request.Invocation.create(new GetMailboxMethodCall());
+        final JmapRequest.Call callInfo = multiCall.call(new GetMailboxMethodCall());
 
 
-        final String body = readResourceAsString("fetch-mailboxes/02-mailboxes.json", invocation.getId());
+        final String body = readResourceAsString("fetch-mailboxes/02-mailboxes.json", callInfo.getMethodCallId());
         server.enqueue(new MockResponse().setBody(body));
 
-        final ListenableFuture<MethodResponses> future = multiCall.add(invocation);
+        final ListenableFuture<MethodResponses> future = callInfo.getFuture();
 
         multiCall.execute();
 
@@ -105,13 +104,13 @@ public class HttpJmapClientTest {
 
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
 
-        final Request.Invocation invocation = Request.Invocation.create(new GetMailboxMethodCall());
+        final JmapRequest.Call callInfo = multiCall.call(new GetMailboxMethodCall());
 
 
-        final String body = readResourceAsString("fetch-mailboxes/unknown-method.json", invocation.getId());
+        final String body = readResourceAsString("fetch-mailboxes/unknown-method.json", callInfo.getMethodCallId());
         server.enqueue(new MockResponse().setBody(body));
 
-        final ListenableFuture<MethodResponses> future = multiCall.add(invocation);
+        final ListenableFuture<MethodResponses> future = callInfo.getFuture();
 
         multiCall.execute();
 

--- a/jmap-client/src/test/resources/fetch-mailboxes/02-mailboxes.json
+++ b/jmap-client/src/test/resources/fetch-mailboxes/02-mailboxes.json
@@ -177,7 +177,7 @@
         "notFound": [],
         "accountId": "test@example.com"
       },
-      "%s"
+      "0"
     ]
   ],
   "sessionState": "0"

--- a/jmap-client/src/test/resources/fetch-mailboxes/unknown-method-call-id.json
+++ b/jmap-client/src/test/resources/fetch-mailboxes/unknown-method-call-id.json
@@ -1,0 +1,1 @@
+{"methodResponses":[["error",{"type":"unknownMethod"},"method_call_id_does_not_match_request"]],"sessionState":"0"}

--- a/jmap-client/src/test/resources/fetch-mailboxes/unknown-method.json
+++ b/jmap-client/src/test/resources/fetch-mailboxes/unknown-method.json
@@ -1,1 +1,1 @@
-{"methodResponses":[["error",{"type":"unknownMethod"},"%s"]],"sessionState":"0"}
+{"methodResponses":[["error",{"type":"unknownMethod"},"0"]],"sessionState":"0"}

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/Request.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/Request.java
@@ -19,7 +19,6 @@ package rs.ltt.jmap.common;
 import rs.ltt.jmap.common.method.MethodCall;
 import rs.ltt.jmap.common.util.Namespace;
 
-import java.security.SecureRandom;
 import java.util.*;
 
 public class Request {
@@ -47,9 +46,6 @@ public class Request {
 
     public static class Invocation {
 
-        private static final int ID_LENGTH = 10;
-        private static final char[] AVAILABLE_CHARS_FOR_ID_GENERATION = "abcdefghijklmnopqrstovwxyz".toCharArray();
-        private static final SecureRandom SECURE_RANDOM = new SecureRandom();
         private MethodCall methodCall;
         private String id;
         private Invocation() {
@@ -61,16 +57,8 @@ public class Request {
             this.id = id;
         }
 
-        public static Invocation create(MethodCall methodCall) {
-            return new Invocation(methodCall, nextId());
-        }
-
-        private static String nextId() {
-            char[] id = new char[ID_LENGTH];
-            for (int i = 0; i < ID_LENGTH; ++i) {
-                id[i] = AVAILABLE_CHARS_FOR_ID_GENERATION[SECURE_RANDOM.nextInt(AVAILABLE_CHARS_FOR_ID_GENERATION.length - 1)];
-            }
-            return String.valueOf(id);
+        public static Invocation create(MethodCall methodCall, String id) {
+            return new Invocation(methodCall, id);
         }
 
         public MethodCall getMethodCall() {

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
@@ -9,9 +9,11 @@ import rs.ltt.jmap.common.method.call.email.QueryEmailMethodCall;
 
 public class ResultReferenceTypeAdapterTest {
 
+    private static final String METHOD_CALL_ID = "#1";
+
     @Test
     public void writeAndReadBack() {
-        Request.Invocation emailQuery = Request.Invocation.create(new QueryEmailMethodCall());
+        Request.Invocation emailQuery = Request.Invocation.create(new QueryEmailMethodCall(), METHOD_CALL_ID);
         Request.Invocation.ResultReference resultReferenceOut = emailQuery.createReference("/ids");
         GsonBuilder gsonBuilder = new GsonBuilder();
         ResultReferenceTypeAdapter.register(gsonBuilder);

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/CreateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/CreateUtil.java
@@ -36,7 +36,7 @@ public class CreateUtil {
         }
         final Optional<ListenableFuture<MethodResponses>> mailboxCreateFutureOptional;
         if (mailbox == null) {
-            return Optional.of(multiCall.call(new SetMailboxMethodCall(ImmutableMap.of(createId(role), MailboxUtil.create(role)))));
+            return Optional.of(multiCall.call(new SetMailboxMethodCall(ImmutableMap.of(createId(role), MailboxUtil.create(role)))).getMethodResponses());
         } else {
             return Optional.absent();
         }

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
@@ -18,9 +18,9 @@ package rs.ltt.jmap.mua.util;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import rs.ltt.jmap.client.JmapClient;
+import rs.ltt.jmap.client.JmapRequest;
 import rs.ltt.jmap.client.MethodResponses;
 import rs.ltt.jmap.common.Request;
-import rs.ltt.jmap.common.entity.Email;
 import rs.ltt.jmap.common.method.call.email.ChangesEmailMethodCall;
 import rs.ltt.jmap.common.method.call.email.GetEmailMethodCall;
 import rs.ltt.jmap.common.method.call.identity.ChangesIdentityMethodCall;
@@ -32,87 +32,59 @@ import rs.ltt.jmap.common.method.call.thread.GetThreadMethodCall;
 
 public class UpdateUtil {
 
-    private static MethodResponsesFuture add(JmapClient.MultiCall multiCall, Invocation invocation) {
-        final ListenableFuture<MethodResponses> changes = multiCall.add(invocation.changes);
-        final ListenableFuture<MethodResponses> created = multiCall.add(invocation.created);
-        final ListenableFuture<MethodResponses> updated = multiCall.add(invocation.updated);
+    public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String state) {
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesEmailMethodCall(state));
+        final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(new GetEmailMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED),
+                true
+        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetEmailMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
+                true
+        )).getMethodResponses();
+
         return new MethodResponsesFuture(changes, created, updated);
     }
 
-    public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String state) {
-        return add(multiCall, emails(state));
-    }
-
-    private static Invocation emails(String state) {
-        final Request.Invocation changes = Request.Invocation.create(new ChangesEmailMethodCall(state));
-        final Request.Invocation created = Request.Invocation.create(new GetEmailMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.CREATED),
-                true
-        ));
-        final Request.Invocation updated = Request.Invocation.create(new GetEmailMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.UPDATED),
-                Email.MUTABLE_PROPERTIES
-        ));
-        return new Invocation(changes, created, updated);
-    }
-
     public static MethodResponsesFuture identities(JmapClient.MultiCall multiCall, String state) {
-        return add(multiCall, identities(state));
-    }
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesIdentityMethodCall(state));
+        final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(new GetIdentityMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
+        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetIdentityMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
+        )).getMethodResponses();
 
-    private static Invocation identities(String state) {
-        final Request.Invocation changes = Request.Invocation.create(new ChangesIdentityMethodCall(state));
-        final Request.Invocation created = Request.Invocation.create(new GetIdentityMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.CREATED)
-        ));
-        final Request.Invocation updated = Request.Invocation.create(new GetIdentityMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.UPDATED)
-        ));
-        return new Invocation(changes, created, updated);
+        return new MethodResponsesFuture(changes, created, updated);
     }
 
     public static MethodResponsesFuture mailboxes(JmapClient.MultiCall multiCall, String state) {
-        return add(multiCall, mailboxes(state));
-    }
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesMailboxMethodCall(state));
+        final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(new GetMailboxMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
+        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetMailboxMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED_PROPERTIES)
+        )).getMethodResponses();
 
-    private static Invocation mailboxes(String state) {
-        final Request.Invocation changes = Request.Invocation.create(new ChangesMailboxMethodCall(state));
-        final Request.Invocation created = Request.Invocation.create(new GetMailboxMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.CREATED)
-        ));
-        final Request.Invocation updated = Request.Invocation.create(new GetMailboxMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.UPDATED),
-                changes.createReference(Request.Invocation.ResultReference.Path.UPDATED_PROPERTIES)
-        ));
-        return new Invocation(changes, created, updated);
+        return new MethodResponsesFuture(changes, created, updated);
     }
 
     public static MethodResponsesFuture threads(JmapClient.MultiCall multiCall, String state) {
-        return add(multiCall, threads(state));
-    }
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesThreadMethodCall(state));
+        final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(new GetThreadMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
+        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetThreadMethodCall(
+                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
+        )).getMethodResponses();
 
-    private static Invocation threads(String state) {
-        final Request.Invocation changes = Request.Invocation.create(new ChangesThreadMethodCall(state));
-        final Request.Invocation created = Request.Invocation.create(new GetThreadMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.CREATED)
-        ));
-        final Request.Invocation updated = Request.Invocation.create(new GetThreadMethodCall(
-                changes.createReference(Request.Invocation.ResultReference.Path.UPDATED)
-        ));
-        return new Invocation(changes, created, updated);
-    }
-
-    public static class Invocation {
-
-        public final Request.Invocation changes;
-        public final Request.Invocation created;
-        public final Request.Invocation updated;
-
-        private Invocation(Request.Invocation changes, Request.Invocation created, Request.Invocation updated) {
-            this.changes = changes;
-            this.created = created;
-            this.updated = updated;
-        }
+        return new MethodResponsesFuture(changes, created, updated);
     }
 
     public static class MethodResponsesFuture {


### PR DESCRIPTION
The previous MultiCall example:

```java
JmapClient client = new JmapClient("user@example.com", "password");

JmapClient.MultiCall multiCall = client.newMultiCall();

//create a query request
Request.Invocation emailQuery = Request.Invocation.create(
    new QueryEmailMethodCall(EmailQuery.unfiltered())
);
//create a get email request with a back reference to the IDs found in the previous request
Request.Invocation emailGet = Request.Invocation.create(
    new GetEmailMethodCall(emailQuery.createReference(Request.Invocation.ResultReference.Path.IDS))
);

//add both method calls to multi call
Future<MethodResponses> queryFuture = multiCall.add(emailQuery);
Future<MethodResponses> getFuture = multiCall.add(emailGet);

multiCall.execute();

//process responses
QueryEmailMethodResponse emailQueryResponse = queryFuture.get().getMain(QueryEmailMethodResponse.class);
GetEmailMethodResponse getEmailMethodResponse = getFuture.get().getMain(GetEmailMethodResponse.class);
for (Email email : getEmailMethodResponse.getList()) {
    System.out.println(email.getSentAt() + " " + email.getFrom() + " " + email.getSubject());
}
```

would now be:

```java
JmapClient client = new JmapClient("user@example.com", "password");

JmapClient.MultiCall multiCall = client.newMultiCall();

//create a query request
Call queryEmailCall = multiCall.call(
        new QueryEmailMethodCall(EmailQuery.unfiltered())
);

//create a get email request with a back reference to the IDs found in the previous request
Call getEmailCall = multiCall.call(
        new GetEmailMethodCall(queryEmailCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))
);

multiCall.execute();

//process responses
QueryEmailMethodResponse emailQueryResponse = queryEmailCall.getMethodResponses().get().getMain(QueryEmailMethodResponse.class);
GetEmailMethodResponse getEmailMethodResponse = getEmailCall.getMethodResponses().get().getMain(GetEmailMethodResponse.class);
for (Email email : getEmailMethodResponse.getList()) {
    System.out.println(email.getSentAt() + " " + email.getFrom() + " " + email.getSubject());
}
```

It's safer in that you can't add the `GetEmailMethodCall` that references the `QueryEmailMethodCall` result before adding the `QueryEmailMethodCall`.

This change in API allowed to simplify the method call id generation code. Every `JmapRequest` now uses sequential method call ids starting with `#1`. This in turn allowed to simplify the tests in `HttpJmapClientTest`.