### PR TITLE
Re-fetch SessionResource when session state changes

### DIFF
--- a/jmap-client/src/main/java/rs/ltt/jmap/client/JmapClient.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/JmapClient.java
@@ -24,6 +24,7 @@ import org.checkerframework.checker.nullness.compatqual.NonNullDecl;
 import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import rs.ltt.jmap.client.api.HttpJmapApiClient;
 import rs.ltt.jmap.client.api.JmapApiClient;
+import rs.ltt.jmap.client.api.SessionStateListener;
 import rs.ltt.jmap.client.http.BasicAuthHttpAuthentication;
 import rs.ltt.jmap.client.http.HttpAuthentication;
 import rs.ltt.jmap.client.session.Session;
@@ -42,6 +43,13 @@ public class JmapClient implements Closeable {
     private final HttpAuthentication authentication;
 
     private ListeningExecutorService executorService = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(2));
+
+    private final SessionStateListener sessionStateListener = new SessionStateListener() {
+        @Override
+        public void onSessionStateRetrieved(String sessionState) {
+            sessionClient.setLatestSessionState(sessionState);
+        }
+    };
 
     public JmapClient(HttpAuthentication httpAuthentication) {
         this.authentication = httpAuthentication;
@@ -101,7 +109,7 @@ public class JmapClient implements Closeable {
                 if (session == null) {
                     return;
                 }
-                JmapApiClient apiClient = new HttpJmapApiClient(session.getApiUrl(), authentication);
+                JmapApiClient apiClient = new HttpJmapApiClient(session.getApiUrl(), authentication, sessionStateListener);
                 apiClient.execute(request);
             }
 

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/api/HttpJmapApiClient.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/api/HttpJmapApiClient.java
@@ -18,6 +18,7 @@ package rs.ltt.jmap.client.api;
 
 
 import okhttp3.*;
+import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rs.ltt.jmap.client.http.BasicAuthHttpAuthentication;
@@ -37,19 +38,28 @@ public class HttpJmapApiClient extends AbstractJmapApiClient {
 
     private final URL apiUrl;
     private final HttpAuthentication httpAuthentication;
+    private final SessionStateListener sessionStateListener;
 
     public HttpJmapApiClient(final URL apiUrl, String username, String password) {
-        this(apiUrl, new BasicAuthHttpAuthentication(username, password));
+        this(apiUrl, new BasicAuthHttpAuthentication(username, password), null);
     }
 
     public HttpJmapApiClient(final URL apiUrl, final HttpAuthentication httpAuthentication) {
+        this(apiUrl,httpAuthentication, null);
+    }
+
+    public HttpJmapApiClient(final URL apiUrl, final HttpAuthentication httpAuthentication, @NullableDecl final SessionStateListener sessionStateListener) {
         this.apiUrl = apiUrl;
         this.httpAuthentication = httpAuthentication;
+        this.sessionStateListener = sessionStateListener;
     }
 
     @Override
     void onSessionStateRetrieved(final String sessionState) {
         LOGGER.debug("Notified of session state='{}'", sessionState);
+        if (sessionStateListener != null) {
+            sessionStateListener.onSessionStateRetrieved(sessionState);
+        }
     }
 
     @Override

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/api/SessionStateListener.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/api/SessionStateListener.java
@@ -1,0 +1,5 @@
+package rs.ltt.jmap.client.api;
+
+public interface SessionStateListener {
+    void onSessionStateRetrieved(String sessionState);
+}

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/session/Session.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/session/Session.java
@@ -38,4 +38,8 @@ public class Session {
     public URL getBase() {
         return base;
     }
+
+    public String getState() {
+        return sessionResource.getState();
+    }
 }

--- a/jmap-client/src/test/resources/update-session-resource/01-session.json
+++ b/jmap-client/src/test/resources/update-session-resource/01-session.json
@@ -1,0 +1,34 @@
+﻿{
+  "username": "test@example.com",
+  "apiUrl": "/jmap/",
+  "downloadUrl": "/jmap/download/{accountId}/{blobId}/{name}?accept={type}",
+  "uploadUrl": "/jmap/upload/{accountId}/",
+  "accounts": {
+    "test@example.com": {
+      "name": "test@example.com",
+      "isPersonal": true,
+      "isReadOnly": false
+    }
+  },
+  "capabilities": {
+    "urn:ietf:params:jmap:core": {
+      "maxSizeUpload": 1073741824,
+      "maxConcurrentUpload": 5,
+      "maxCallsInRequest": 50,
+      "maxObjectsInGet": 4096,
+      "maxObjectsInSet": 4096,
+      "collationAlgorithms": []
+    },
+    "urn:ietf:params:jmap:mail": {
+      "maxMailboxesPerEmail": 0,
+      "maxMailboxDepth": 0,
+      "maxSizeMailboxName": 0,
+      "maxSizeAttachmentsPerEmail": 0
+    },
+    "urn:ietf:params:jmap:submission": {
+      "maxDelayedSend": 0
+    },
+    "urn:ietf:params:jmap:vacationresponse": {}
+  },
+  "state": "0"
+}

--- a/jmap-client/src/test/resources/update-session-resource/02-mailboxes.json
+++ b/jmap-client/src/test/resources/update-session-resource/02-mailboxes.json
@@ -1,0 +1,40 @@
+﻿{
+  "methodResponses": [
+    [
+      "Mailbox/get",
+      {
+        "state": "4011",
+        "list": [
+          {
+            "id": "46b9c2ce-7a7c-4736-9711-02a22491a02b",
+            "name": "Inbox",
+            "parentId": null,
+            "myRights": {
+              "mayReadItems": true,
+              "mayAddItems": true,
+              "mayRemoveItems": true,
+              "mayCreateChild": true,
+              "mayDelete": false,
+              "maySubmit": true,
+              "maySetSeen": true,
+              "maySetKeywords": true,
+              "mayAdmin": true,
+              "mayRename": false
+            },
+            "role": "inbox",
+            "totalEmails": 238,
+            "unreadEmails": 6,
+            "totalThreads": 80,
+            "unreadThreads": 4,
+            "sortOrder": 1,
+            "isSubscribed": false
+          }
+        ],
+        "notFound": [],
+        "accountId": "test@example.com"
+      },
+      "0"
+    ]
+  ],
+  "sessionState": "1"
+}

--- a/jmap-client/src/test/resources/update-session-resource/03-session.json
+++ b/jmap-client/src/test/resources/update-session-resource/03-session.json
@@ -1,0 +1,34 @@
+﻿{
+  "username": "test@example.com",
+  "apiUrl": "/api/jmap/",
+  "downloadUrl": "/jmap/download/{accountId}/{blobId}/{name}?accept={type}",
+  "uploadUrl": "/jmap/upload/{accountId}/",
+  "accounts": {
+    "test@example.com": {
+      "name": "test@example.com",
+      "isPersonal": true,
+      "isReadOnly": false
+    }
+  },
+  "capabilities": {
+    "urn:ietf:params:jmap:core": {
+      "maxSizeUpload": 1073741824,
+      "maxConcurrentUpload": 5,
+      "maxCallsInRequest": 50,
+      "maxObjectsInGet": 4096,
+      "maxObjectsInSet": 4096,
+      "collationAlgorithms": []
+    },
+    "urn:ietf:params:jmap:mail": {
+      "maxMailboxesPerEmail": 0,
+      "maxMailboxDepth": 0,
+      "maxSizeMailboxName": 0,
+      "maxSizeAttachmentsPerEmail": 0
+    },
+    "urn:ietf:params:jmap:submission": {
+      "maxDelayedSend": 0
+    },
+    "urn:ietf:params:jmap:vacationresponse": {}
+  },
+  "state": "1"
+}

--- a/jmap-client/src/test/resources/update-session-resource/04-echo.json
+++ b/jmap-client/src/test/resources/update-session-resource/04-echo.json
@@ -1,0 +1,8 @@
+﻿{
+  "methodResponses": [
+    [
+      "Core/echo", {"libraryName":  "ltt.rs"}, "0"
+    ]
+  ],
+  "sessionState": "1"
+}


### PR DESCRIPTION
Right now the `sessionState` property of the response is more or less ignored.  This PR adds a listener to `HttpJmapApiClient` that is used by `JmapClient` to let `SessionClient` know about the latest `sessionState` value. `SessionClient` will then check if the `sessionState` value has changed and re-fetch the session resource the next time someone calls `SessionClient.get()`.