### PR TITLE
Add required accountId parameter to JMAP methods

### DIFF
--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -17,9 +17,11 @@
 package rs.ltt.jmap.client;
 
 import rs.ltt.jmap.client.JmapRequest.Call;
+import rs.ltt.jmap.client.session.Session;
 import rs.ltt.jmap.client.session.SessionFileCache;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Email;
+import rs.ltt.jmap.common.entity.capability.MailAccountCapability;
 import rs.ltt.jmap.common.entity.filter.EmailFilterCondition;
 import rs.ltt.jmap.common.entity.filter.Filter;
 import rs.ltt.jmap.common.entity.filter.FilterOperator;
@@ -51,6 +53,9 @@ public class Main {
 
             //System.out.println("Echo call result: " + methodResponsesFuture.get().getMain(EchoMethodResponse.class).toString());
 
+            Session session = client.getSession().get();
+            String accountId = session.getPrimaryAccount(MailAccountCapability.class);
+
             final JmapClient.MultiCall multiCall = client.newMultiCall();
 
             Filter<Email> emailFilter = FilterOperator.and(
@@ -62,7 +67,7 @@ public class Main {
             Call emailQueryCall = multiCall.call(new QueryEmailMethodCall(emailFilter));
             Future<MethodResponses> emailQueryResponseFuture = emailQueryCall.getMethodResponses();
 
-            Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
+            Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
 
             multiCall.execute();
             final QueryEmailMethodResponse emailQueryResponse = emailQueryResponseFuture.get().getMain(QueryEmailMethodResponse.class);
@@ -79,7 +84,7 @@ public class Main {
                 Call emailQueryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(currentState, emailFilter));
                 Future<MethodResponses> emailQueryChangesResponseFuture = emailQueryChangesCall.getMethodResponses();
 
-                Future<MethodResponses> emailGetAddedResponseFuture = multiCall.call(new GetEmailMethodCall(emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))).getMethodResponses();
+                Future<MethodResponses> emailGetAddedResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))).getMethodResponses();
 
                 updateMultiCall.execute();
                 QueryChangesEmailMethodResponse emailQueryChangesResponse = emailQueryChangesResponseFuture.get().getMain(QueryChangesEmailMethodResponse.class);

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -81,7 +81,7 @@ public class Main {
                 Thread.sleep(5000);
                 final JmapClient.MultiCall updateMultiCall = client.newMultiCall();
 
-                Call emailQueryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(currentState, emailFilter));
+                Call emailQueryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(accountId, currentState, emailFilter));
                 Future<MethodResponses> emailQueryChangesResponseFuture = emailQueryChangesCall.getMethodResponses();
 
                 Future<MethodResponses> emailGetAddedResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))).getMethodResponses();

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -64,7 +64,7 @@ public class Main {
                     EmailFilterCondition.builder().text("test").build()
             );
 
-            Call emailQueryCall = multiCall.call(new QueryEmailMethodCall(emailFilter));
+            Call emailQueryCall = multiCall.call(new QueryEmailMethodCall(accountId, emailFilter));
             Future<MethodResponses> emailQueryResponseFuture = emailQueryCall.getMethodResponses();
 
             Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/session/Session.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/session/Session.java
@@ -26,6 +26,7 @@ import org.checkerframework.checker.nullness.compatqual.NullableDecl;
 import rs.ltt.jmap.client.event.CloseAfter;
 import rs.ltt.jmap.common.SessionResource;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
+import rs.ltt.jmap.common.entity.AccountCapability;
 
 import java.util.Collection;
 import java.util.Locale;
@@ -102,5 +103,9 @@ public class Session {
 
     public String getState() {
         return sessionResource.getState();
+    }
+
+    public String getPrimaryAccount(Class<? extends AccountCapability> clazz) {
+        return sessionResource.getPrimaryAccount(clazz);
     }
 }

--- a/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
+++ b/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
@@ -48,6 +48,7 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 
 public class HttpJmapClientTest {
 
+    private static String ACCOUNT_ID = "test@example.com";
     private static String USERNAME = "test@example.com";
     private static String PASSWORD = "secret";
     private static String WELL_KNOWN_PATH = ".well-known/jmap";
@@ -69,7 +70,7 @@ public class HttpJmapClientTest {
         );
 
 
-        final ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall());
+        final ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
 
 
         final GetMailboxMethodResponse mailboxResponse = future.get().getMain(GetMailboxMethodResponse.class);
@@ -97,7 +98,7 @@ public class HttpJmapClientTest {
         );
 
 
-        ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall());
+        ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
 
 
         try {
@@ -127,7 +128,7 @@ public class HttpJmapClientTest {
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(CoreMatchers.<Throwable>instanceOf(MethodResponseNotFoundException.class));
-        jmapClient.call(new GetMailboxMethodCall()).get();
+        jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID)).get();
 
         server.shutdown();
     }
@@ -166,7 +167,7 @@ public class HttpJmapClientTest {
                 server.url(WELL_KNOWN_PATH)
         );
 
-        final ListenableFuture<MethodResponses> mailboxFuture = jmapClient.call(new GetMailboxMethodCall());
+        final ListenableFuture<MethodResponses> mailboxFuture = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
 
         // Wait for result
         mailboxFuture.get();

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/ChangesEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/ChangesEmailMethodCall.java
@@ -22,7 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Email/changes")
 public class ChangesEmailMethodCall extends ChangesMethodCall<Email> {
-    public ChangesEmailMethodCall(String sinceState) {
-        super(sinceState);
+    public ChangesEmailMethodCall(String accountId, String sinceState) {
+        super(accountId, sinceState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
@@ -29,31 +29,31 @@ public class GetEmailMethodCall extends GetMethodCall<Email> {
     private Boolean fetchAllBodyValues;
     private Long maxBodyValueBytes;
 
-    public GetEmailMethodCall(Request.Invocation.ResultReference resultReference) {
-        super(resultReference);
+    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
+        super(accountId, resultReference);
     }
 
-    public GetEmailMethodCall(Request.Invocation.ResultReference resultReference, boolean fetchTextBodyValues) {
-        super(resultReference);
+    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference, boolean fetchTextBodyValues) {
+        super(accountId, resultReference);
         this.fetchTextBodyValues = fetchTextBodyValues;
     }
 
-    public GetEmailMethodCall(String[] ids) {
-        super(ids);
+    public GetEmailMethodCall(String accountId, String[] ids) {
+        super(accountId, ids);
     }
 
-    public GetEmailMethodCall(String[] ids, boolean fetchTextBodyValues) {
-        super(ids);
+    public GetEmailMethodCall(String accountId, String[] ids, boolean fetchTextBodyValues) {
+        super(accountId, ids);
         this.fetchTextBodyValues = fetchTextBodyValues;
     }
 
-    public GetEmailMethodCall(Request.Invocation.ResultReference resultReference, String[] properties) {
-        super(resultReference);
+    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference, String[] properties) {
+        super(accountId, resultReference);
         this.properties = properties;
     }
 
-    public GetEmailMethodCall(String[] ids, String[] properties) {
-        super(ids);
+    public GetEmailMethodCall(String accountId, String[] ids, String[] properties) {
+        super(accountId, ids);
         this.properties = properties;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryChangesEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryChangesEmailMethodCall.java
@@ -27,16 +27,16 @@ public class QueryChangesEmailMethodCall extends QueryChangesMethodCall<Email> {
 
     private Boolean collapseThreads;
 
-    public QueryChangesEmailMethodCall(String sinceQueryState, Filter<Email> filter) {
-        super(sinceQueryState, filter);
+    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState, Filter<Email> filter) {
+        super(accountId, sinceQueryState, filter);
     }
 
-    public QueryChangesEmailMethodCall(String sinceQueryState, EmailQuery query) {
-        super(sinceQueryState, query);
+    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState, EmailQuery query) {
+        super(accountId, sinceQueryState, query);
         this.collapseThreads = query.collapseThreads;
     }
 
-    public QueryChangesEmailMethodCall(String sinceQueryState) {
-        super(sinceQueryState);
+    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState) {
+        super(accountId, sinceQueryState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
@@ -27,31 +27,31 @@ public class QueryEmailMethodCall extends QueryMethodCall<Email> {
 
     private Boolean collapseThreads;
 
-    public QueryEmailMethodCall() {
-        super();
+    public QueryEmailMethodCall(String accountId) {
+        super(accountId);
     }
 
-    public QueryEmailMethodCall(Filter<Email> filter) {
-        super(filter);
+    public QueryEmailMethodCall(String accountId, Filter<Email> filter) {
+        super(accountId, filter);
     }
 
-    public QueryEmailMethodCall(EmailQuery query) {
-        super(query);
+    public QueryEmailMethodCall(String accountId, EmailQuery query) {
+        super(accountId, query);
         this.collapseThreads = query.collapseThreads;
     }
 
-    public QueryEmailMethodCall(EmailQuery query, Long limit) {
-        super(query, limit);
+    public QueryEmailMethodCall(String accountId, EmailQuery query, Long limit) {
+        super(accountId, query, limit);
         this.collapseThreads = query.collapseThreads;
     }
 
-    public QueryEmailMethodCall(EmailQuery query, String afterEmailId) {
-        super(query, afterEmailId);
+    public QueryEmailMethodCall(String accountId, EmailQuery query, String afterEmailId) {
+        super(accountId, query, afterEmailId);
         this.collapseThreads = query.collapseThreads;
     }
 
-    public QueryEmailMethodCall(EmailQuery query, String afterEmailId, Long limit) {
-        super(query, afterEmailId, limit);
+    public QueryEmailMethodCall(String accountId, EmailQuery query, String afterEmailId, Long limit) {
+        super(accountId, query, afterEmailId, limit);
         this.collapseThreads = query.collapseThreads;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/SetEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/SetEmailMethodCall.java
@@ -30,20 +30,20 @@ public class SetEmailMethodCall extends SetMethodCall<Email> {
         super(accountId, ifInState, create, update, destroy);
     }
 
-    public SetEmailMethodCall(String ifInState, String[] destroy) {
-        super(ifInState, destroy);
+    public SetEmailMethodCall(String accountId, String ifInState, String[] destroy) {
+        super(accountId, ifInState, destroy);
     }
 
-    public SetEmailMethodCall(String ifInState, Request.Invocation.ResultReference destroy) {
-        super(ifInState, destroy);
+    public SetEmailMethodCall(String accountId, String ifInState, Request.Invocation.ResultReference destroy) {
+        super(accountId, ifInState, destroy);
     }
 
 
-    public SetEmailMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
-        super(ifInState, update);
+    public SetEmailMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        super(accountId, ifInState, update);
     }
 
-    public SetEmailMethodCall(Map<String, Email> create) {
-        super(create);
+    public SetEmailMethodCall(String accountId, Map<String, Email> create) {
+        super(accountId, create);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/ChangesIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/ChangesIdentityMethodCall.java
@@ -22,7 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Identity/changes")
 public class ChangesIdentityMethodCall extends ChangesMethodCall<Identity> {
-    public ChangesIdentityMethodCall(String sinceState) {
-        super(sinceState);
+    public ChangesIdentityMethodCall(String accountId, String sinceState) {
+        super(accountId, sinceState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/GetIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/GetIdentityMethodCall.java
@@ -24,16 +24,16 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 @JmapMethod("Identity/get")
 public class GetIdentityMethodCall extends GetMethodCall<Identity> {
 
-    public GetIdentityMethodCall(Request.Invocation.ResultReference resultReference) {
-        super(resultReference);
+    public GetIdentityMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
+        super(accountId, resultReference);
     }
 
-    public GetIdentityMethodCall(String[] ids) {
-        super(ids);
+    public GetIdentityMethodCall(String accountId, String[] ids) {
+        super(accountId, ids);
     }
 
-    public GetIdentityMethodCall() {
-        super();
+    public GetIdentityMethodCall(String accountId) {
+        super(accountId);
     }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/SetIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/SetIdentityMethodCall.java
@@ -28,15 +28,15 @@ public class SetIdentityMethodCall extends SetMethodCall<Identity> {
         super(accountId, ifInState, create, update, destroy);
     }
 
-    public SetIdentityMethodCall(String ifInState, String[] destroy) {
-        super(ifInState, destroy);
+    public SetIdentityMethodCall(String accountId, String ifInState, String[] destroy) {
+        super(accountId, ifInState, destroy);
     }
 
-    public SetIdentityMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
-        super(ifInState, update);
+    public SetIdentityMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        super(accountId, ifInState, update);
     }
 
-    public SetIdentityMethodCall(Map<String, Identity> create) {
-        super(create);
+    public SetIdentityMethodCall(String accountId, Map<String, Identity> create) {
+        super(accountId, create);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/ChangesMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/ChangesMailboxMethodCall.java
@@ -22,7 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Mailbox/changes")
 public class ChangesMailboxMethodCall extends ChangesMethodCall<Mailbox> {
-    public ChangesMailboxMethodCall(String sinceState) {
-        super(sinceState);
+    public ChangesMailboxMethodCall(String accountId, String sinceState) {
+        super(accountId, sinceState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
@@ -28,20 +28,20 @@ public class GetMailboxMethodCall extends GetMethodCall<Mailbox> {
     @SerializedName("#properties")
     private Request.Invocation.ResultReference propertiesReference;
 
-    public GetMailboxMethodCall() {
-        super();
+    public GetMailboxMethodCall(String accountId) {
+        super(accountId);
     }
 
-    public GetMailboxMethodCall(Request.Invocation.ResultReference resultReference) {
-        super(resultReference);
+    public GetMailboxMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
+        super(accountId, resultReference);
     }
 
-    public GetMailboxMethodCall(Request.Invocation.ResultReference idsReference, Request.Invocation.ResultReference propertiesReference) {
-        super(idsReference);
+    public GetMailboxMethodCall(String accountId, Request.Invocation.ResultReference idsReference, Request.Invocation.ResultReference propertiesReference) {
+        super(accountId, idsReference);
         this.propertiesReference = propertiesReference;
     }
 
-    public GetMailboxMethodCall(String[] ids) {
-        super(ids);
+    public GetMailboxMethodCall(String accountId, String[] ids) {
+        super(accountId, ids);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryChangesMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryChangesMailboxMethodCall.java
@@ -25,15 +25,15 @@ import rs.ltt.jmap.common.method.call.standard.QueryChangesMethodCall;
 @JmapMethod("Mailbox/queryChanges")
 public class QueryChangesMailboxMethodCall extends QueryChangesMethodCall<Mailbox> {
 
-    public QueryChangesMailboxMethodCall(String sinceQueryState, Filter<Mailbox> filter) {
-        super(sinceQueryState, filter);
+    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState, Filter<Mailbox> filter) {
+        super(accountId, sinceQueryState, filter);
     }
 
-    public QueryChangesMailboxMethodCall(String sinceQueryState, Query<Mailbox> query) {
-        super(sinceQueryState, query);
+    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState, Query<Mailbox> query) {
+        super(accountId, sinceQueryState, query);
     }
 
-    public QueryChangesMailboxMethodCall(String sinceQueryState) {
-        super(sinceQueryState);
+    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState) {
+        super(accountId, sinceQueryState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
@@ -29,30 +29,30 @@ public class QueryMailboxMethodCall extends QueryMethodCall<Mailbox> {
 
     private Boolean filterAsTree;
 
-    public QueryMailboxMethodCall(Filter<Mailbox> filter) {
-        super(filter);
+    public QueryMailboxMethodCall(String accountId, Filter<Mailbox> filter) {
+        super(accountId, filter);
     }
 
-    public QueryMailboxMethodCall(MailboxQuery query) {
-        super(query);
+    public QueryMailboxMethodCall(String accountId, MailboxQuery query) {
+        super(accountId, query);
         this.sortAsTree = query.sortAsTree;
         this.filterAsTree = query.filterAsTree;
     }
 
-    public QueryMailboxMethodCall(MailboxQuery query, String afterId) {
-        super(query, afterId);
+    public QueryMailboxMethodCall(String accountId, MailboxQuery query, String afterId) {
+        super(accountId, query, afterId);
         this.sortAsTree = query.sortAsTree;
         this.filterAsTree = query.filterAsTree;
     }
 
-    public QueryMailboxMethodCall(MailboxQuery query, Long limit) {
-        super(query, limit);
+    public QueryMailboxMethodCall(String accountId, MailboxQuery query, Long limit) {
+        super(accountId, query, limit);
         this.sortAsTree = query.sortAsTree;
         this.filterAsTree = query.filterAsTree;
     }
 
-    public QueryMailboxMethodCall(MailboxQuery query, String afterId, Long limit) {
-        super(query, afterId, limit);
+    public QueryMailboxMethodCall(String accountId, MailboxQuery query, String afterId, Long limit) {
+        super(accountId, query, afterId, limit);
         this.sortAsTree = query.sortAsTree;
         this.filterAsTree = query.filterAsTree;
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/SetMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/SetMailboxMethodCall.java
@@ -36,20 +36,20 @@ public class SetMailboxMethodCall extends SetMethodCall<Mailbox> {
         this.onDestroyRemoveEmails = onDestroyRemoveEmails;
     }
 
-    public SetMailboxMethodCall(String ifInState, String[] destroy) {
-        super(ifInState, destroy);
+    public SetMailboxMethodCall(String accountId, String ifInState, String[] destroy) {
+        super(accountId, ifInState, destroy);
     }
 
-    public SetMailboxMethodCall(String ifInState, String[] destroy, Boolean onDestroyRemoveEmails) {
-        super(ifInState, destroy);
+    public SetMailboxMethodCall(String accountId, String ifInState, String[] destroy, Boolean onDestroyRemoveEmails) {
+        super(accountId, ifInState, destroy);
         this.onDestroyRemoveEmails = onDestroyRemoveEmails;
     }
 
-    public SetMailboxMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
-        super(ifInState, update);
+    public SetMailboxMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        super(accountId, ifInState, update);
     }
 
-    public SetMailboxMethodCall(Map<String, Mailbox> create) {
-        super(create);
+    public SetMailboxMethodCall(String accountId, Map<String, Mailbox> create) {
+        super(accountId, create);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
@@ -34,12 +34,14 @@ public class GetSearchSnippetsMethodCall implements MethodCall {
     @SerializedName("#ids")
     private Request.Invocation.ResultReference idsReference;
 
-    public GetSearchSnippetsMethodCall(Request.Invocation.ResultReference idsReference, Filter<Email> filter) {
+    public GetSearchSnippetsMethodCall(String accountId, Request.Invocation.ResultReference idsReference, Filter<Email> filter) {
+        this.accountId = accountId;
         this.idsReference = idsReference;
         this.filter = filter;
     }
 
-    public GetSearchSnippetsMethodCall(String[] ids, Filter<Email> filter) {
+    public GetSearchSnippetsMethodCall(String accountId, String[] ids, Filter<Email> filter) {
+        this.accountId = accountId;
         this.ids = ids;
         this.filter = filter;
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
@@ -25,7 +25,8 @@ public abstract class ChangesMethodCall<T extends AbstractIdentifiableEntity> im
     private String sinceState;
     private Long maxChanges;
 
-    public ChangesMethodCall(String sinceState) {
+    public ChangesMethodCall(String accountId, String sinceState) {
+        this.accountId = accountId;
         this.sinceState = sinceState;
     }
 

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
@@ -30,17 +30,19 @@ public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implem
     @SerializedName("#ids")
     private Request.Invocation.ResultReference idsReference;
 
-    public GetMethodCall(Request.Invocation.ResultReference idsReference) {
+    public GetMethodCall(String accountId, Request.Invocation.ResultReference idsReference) {
+        this.accountId = accountId;
         this.idsReference = idsReference;
     }
 
 
-    public GetMethodCall(String[] ids) {
+    public GetMethodCall(String accountId, String[] ids) {
+        this.accountId = accountId;
         this.ids = ids;
     }
 
-    public GetMethodCall() {
-
+    public GetMethodCall(String accountId) {
+        this.accountId = accountId;
     }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
@@ -32,18 +32,21 @@ public abstract class QueryChangesMethodCall<T extends AbstractIdentifiableEntit
     private String upToId;
     private Boolean calculateTotal;
 
-    public QueryChangesMethodCall(String sinceQueryState, final Filter<T> filter) {
+    public QueryChangesMethodCall(String accountId, String sinceQueryState, final Filter<T> filter) {
+        this.accountId = accountId;
         this.sinceQueryState = sinceQueryState;
         this.filter = filter;
     }
 
-    public QueryChangesMethodCall(String sinceQueryState, final Query<T> query) {
+    public QueryChangesMethodCall(String accountId, String sinceQueryState, final Query<T> query) {
+        this.accountId = accountId;
         this.sinceQueryState = sinceQueryState;
         this.filter = query.filter;
         this.sort = query.comparators;
     }
 
-    public QueryChangesMethodCall(String sinceQueryState) {
+    public QueryChangesMethodCall(String accountId, String sinceQueryState) {
+        this.accountId = accountId;
         this.sinceQueryState = sinceQueryState;
     }
 

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
@@ -33,33 +33,38 @@ public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> impl
     private Long anchorOffset;
     private Long limit;
 
-    public QueryMethodCall() {
-        
+    public QueryMethodCall(String accountId) {
+        this.accountId = accountId;
     }
 
-    public QueryMethodCall(Filter<T> filter) {
+    public QueryMethodCall(String accountId, Filter<T> filter) {
+        this.accountId = accountId;
         this.filter = filter;
     }
 
-    public QueryMethodCall(Query<T> query) {
+    public QueryMethodCall(String accountId, Query<T> query) {
+        this.accountId = accountId;
         this.filter = query.filter;
         this.sort = query.comparators;
     }
 
-    public QueryMethodCall(Query<T> query, Long limit) {
+    public QueryMethodCall(String accountId, Query<T> query, Long limit) {
+        this.accountId = accountId;
         this.filter = query.filter;
         this.sort = query.comparators;
         this.limit = limit;
     }
 
-    public QueryMethodCall(Query<T> query, String afterId) {
+    public QueryMethodCall(String accountId, Query<T> query, String afterId) {
+        this.accountId = accountId;
         this.filter = query.filter;
         this.sort = query.comparators;
         this.anchor = afterId;
         this.anchorOffset = 1L;
     }
 
-    public QueryMethodCall(Query<T> query, String afterId, Long limit) {
+    public QueryMethodCall(String accountId, Query<T> query, String afterId, Long limit) {
+        this.accountId = accountId;
         this.filter = query.filter;
         this.sort = query.comparators;
         this.anchor = afterId;

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
@@ -46,22 +46,26 @@ public abstract class SetMethodCall<T extends AbstractIdentifiableEntity> implem
         this.destroy = destroy;
     }
 
-    public SetMethodCall(String ifInState, String[] destroy) {
+    public SetMethodCall(String accountId, String ifInState, String[] destroy) {
+        this.accountId = accountId;
         this.ifInState = ifInState;
         this.destroy = destroy;
     }
 
-    public SetMethodCall(String ifInState, Request.Invocation.ResultReference destroy) {
+    public SetMethodCall(String accountId, String ifInState, Request.Invocation.ResultReference destroy) {
+        this.accountId = accountId;
         this.ifInState = ifInState;
         this.destroyReference = destroy;
     }
 
-    public SetMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
+    public SetMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        this.accountId = accountId;
         this.ifInState = ifInState;
         this.update = update;
     }
 
-    public SetMethodCall(Map<String, T> create) {
+    public SetMethodCall(String accountId, Map<String, T> create) {
+        this.accountId = accountId;
         this.create = create;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/ChangesEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/ChangesEmailSubmissionMethodCall.java
@@ -23,7 +23,7 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 @JmapMethod("EmailSubmission/changes")
 public class ChangesEmailSubmissionMethodCall extends ChangesMethodCall<EmailSubmission> {
 
-    public ChangesEmailSubmissionMethodCall(String sinceState) {
-        super(sinceState);
+    public ChangesEmailSubmissionMethodCall(String accountId, String sinceState) {
+        super(accountId, sinceState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/GetEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/GetEmailSubmissionMethodCall.java
@@ -22,4 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("EmailSubmission/get")
 public class GetEmailSubmissionMethodCall extends GetMethodCall<EmailSubmission> {
+    public GetEmailSubmissionMethodCall(String accountId) {
+        super(accountId);
+    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryChangesEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryChangesEmailSubmissionMethodCall.java
@@ -24,15 +24,15 @@ import rs.ltt.jmap.common.method.call.standard.QueryChangesMethodCall;
 
 @JmapMethod("EmailSubmission/queryChanges")
 public class QueryChangesEmailSubmissionMethodCall extends QueryChangesMethodCall<EmailSubmission> {
-    public QueryChangesEmailSubmissionMethodCall(String sinceQueryState, Filter<EmailSubmission> filter) {
-        super(sinceQueryState, filter);
+    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState, Filter<EmailSubmission> filter) {
+        super(accountId, sinceQueryState, filter);
     }
 
-    public QueryChangesEmailSubmissionMethodCall(String sinceQueryState, Query<EmailSubmission> query) {
-        super(sinceQueryState, query);
+    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState, Query<EmailSubmission> query) {
+        super(accountId, sinceQueryState, query);
     }
 
-    public QueryChangesEmailSubmissionMethodCall(String sinceQueryState) {
-        super(sinceQueryState);
+    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState) {
+        super(accountId, sinceQueryState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
@@ -22,4 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.QueryMethodCall;
 
 @JmapMethod("EmailSubmission/query")
 public class QueryEmailSubmissionMethodCall extends QueryMethodCall<EmailSubmission> {
+    public QueryEmailSubmissionMethodCall(String accountId) {
+        super(accountId);
+    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
@@ -35,30 +35,30 @@ public class SetEmailSubmissionMethodCall extends SetMethodCall<EmailSubmission>
         this.onSuccessDestroyEmail = onSuccessDestroyEmail;
     }
 
-    public SetEmailSubmissionMethodCall(String ifInState, String[] destroy) {
-        super(ifInState, destroy);
+    public SetEmailSubmissionMethodCall(String accountId, String ifInState, String[] destroy) {
+        super(accountId, ifInState, destroy);
     }
 
-    public SetEmailSubmissionMethodCall(String ifInState, String[] destroy, List<String> onSuccessDestroyEmail) {
-        super(ifInState, destroy);
+    public SetEmailSubmissionMethodCall(String accountId, String ifInState, String[] destroy, List<String> onSuccessDestroyEmail) {
+        super(accountId, ifInState, destroy);
         this.onSuccessDestroyEmail = onSuccessDestroyEmail;
     }
 
-    public SetEmailSubmissionMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
-        super(ifInState, update);
+    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        super(accountId, ifInState, update);
     }
 
-    public SetEmailSubmissionMethodCall(String ifInState, Map<String, Map<String, Object>> update, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
-        super(ifInState, update);
+    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
+        super(accountId, ifInState, update);
         this.onSuccessUpdateEmail = onSuccessUpdateEmail;
     }
 
-    public SetEmailSubmissionMethodCall(Map<String, EmailSubmission> create) {
-        super(create);
+    public SetEmailSubmissionMethodCall(String accountId, Map<String, EmailSubmission> create) {
+        super(accountId, create);
     }
 
-    public SetEmailSubmissionMethodCall(Map<String, EmailSubmission> create, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
-        super(create);
+    public SetEmailSubmissionMethodCall(String accountId, Map<String, EmailSubmission> create, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
+        super(accountId, create);
         this.onSuccessUpdateEmail = onSuccessUpdateEmail;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/ChangesThreadMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/ChangesThreadMethodCall.java
@@ -22,7 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Thread/changes")
 public class ChangesThreadMethodCall extends ChangesMethodCall<Thread> {
-    public ChangesThreadMethodCall(String sinceState) {
-        super(sinceState);
+    public ChangesThreadMethodCall(String accountId, String sinceState) {
+        super(accountId, sinceState);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/GetThreadMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/GetThreadMethodCall.java
@@ -24,11 +24,11 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 @JmapMethod("Thread/get")
 public class GetThreadMethodCall extends GetMethodCall<Thread> {
     
-    public GetThreadMethodCall(Request.Invocation.ResultReference resultReference) {
-        super(resultReference);
+    public GetThreadMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
+        super(accountId, resultReference);
     }
 
-    public GetThreadMethodCall(String[] ids) {
-        super(ids);
+    public GetThreadMethodCall(String accountId, String[] ids) {
+        super(accountId, ids);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/GetVacationResponseMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/GetVacationResponseMethodCall.java
@@ -22,4 +22,7 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("VacationResponse/get")
 public class GetVacationResponseMethodCall extends GetMethodCall<VacationResponse> {
+    public GetVacationResponseMethodCall(String accountId) {
+        super(accountId);
+    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/SetVacationResponseMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/SetVacationResponseMethodCall.java
@@ -28,15 +28,15 @@ public class SetVacationResponseMethodCall extends SetMethodCall<VacationRespons
         super(accountId, ifInState, create, update, destroy);
     }
 
-    public SetVacationResponseMethodCall(String ifInState, String[] destroy) {
-        super(ifInState, destroy);
+    public SetVacationResponseMethodCall(String accountId, String ifInState, String[] destroy) {
+        super(accountId, ifInState, destroy);
     }
 
-    public SetVacationResponseMethodCall(String ifInState, Map<String, Map<String, Object>> update) {
-        super(ifInState, update);
+    public SetVacationResponseMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
+        super(accountId, ifInState, update);
     }
 
-    public SetVacationResponseMethodCall(Map<String, VacationResponse> create) {
-        super(create);
+    public SetVacationResponseMethodCall(String accountId, Map<String, VacationResponse> create) {
+        super(accountId, create);
     }
 }

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
@@ -20,7 +20,7 @@ public class QueryCallTest extends AbstractGsonTest {
         Gson gson = builder.create();
         final EmailQuery query = EmailQuery.of(EmailFilterCondition.builder().inMailbox("inbox-id").build(), true);
         Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(new QueryEmailMethodCall(query)));
-        Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("first", query)));
+        Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("accountId", "first", query)));
     }
 
 }

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
@@ -19,7 +19,7 @@ public class QueryCallTest extends AbstractGsonTest {
         JmapAdapters.register(builder);
         Gson gson = builder.create();
         final EmailQuery query = EmailQuery.of(EmailFilterCondition.builder().inMailbox("inbox-id").build(), true);
-        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(new QueryEmailMethodCall(query)));
+        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(new QueryEmailMethodCall("accountId", query)));
         Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("accountId", "first", query)));
     }
 

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
@@ -13,7 +13,7 @@ public class ResultReferenceTypeAdapterTest {
 
     @Test
     public void writeAndReadBack() {
-        Request.Invocation emailQuery = new Request.Invocation(new QueryEmailMethodCall(), METHOD_CALL_ID);
+        Request.Invocation emailQuery = new Request.Invocation(new QueryEmailMethodCall("accountId"), METHOD_CALL_ID);
         Request.Invocation.ResultReference resultReferenceOut = emailQuery.createReference("/ids");
         GsonBuilder gsonBuilder = new GsonBuilder();
         ResultReferenceTypeAdapter.register(gsonBuilder);

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailMethodCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailMethodCallTest.java
@@ -19,7 +19,7 @@ public class SetEmailMethodCallTest extends AbstractGsonTest {
         GsonBuilder builder = new GsonBuilder();
         JmapAdapters.register(builder);
         Gson gson = builder.create();
-        Request request = new Request.Builder().call(new SetEmailMethodCall("state", ImmutableMap.of("M123", Patches.remove("keywords/$seen")))).build();
+        Request request = new Request.Builder().call(new SetEmailMethodCall("accountId", "state", ImmutableMap.of("M123", Patches.remove("keywords/$seen")))).build();
         Assert.assertEquals(readResourceAsString("request/set-email.json"),gson.toJson(request));
     }
 

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailSubmissionMethodCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailSubmissionMethodCallTest.java
@@ -41,6 +41,7 @@ public class SetEmailSubmissionMethodCallTest extends AbstractGsonTest {
         patchesBuilder.remove("keywords/" + Keyword.DRAFT);
         patchesBuilder.set("mailboxIds/MB3", true);
         SetEmailSubmissionMethodCall submissionCall = new SetEmailSubmissionMethodCall(
+                "accountId",
                 ImmutableMap.of(
                         "es0",
                         EmailSubmission.builder()

--- a/jmap-gson/src/test/resources/request/query-changes-email.json
+++ b/jmap-gson/src/test/resources/request/query-changes-email.json
@@ -1,1 +1,1 @@
-{"collapseThreads":true,"filter":{"inMailbox":"inbox-id"},"sinceQueryState":"first"}
+{"collapseThreads":true,"accountId":"accountId","filter":{"inMailbox":"inbox-id"},"sinceQueryState":"first"}

--- a/jmap-gson/src/test/resources/request/query-email.json
+++ b/jmap-gson/src/test/resources/request/query-email.json
@@ -1,1 +1,1 @@
-{"collapseThreads":true,"filter":{"inMailbox":"inbox-id"}}
+{"collapseThreads":true,"accountId":"accountId","filter":{"inMailbox":"inbox-id"}}

--- a/jmap-gson/src/test/resources/request/set-email-submission.json
+++ b/jmap-gson/src/test/resources/request/set-email-submission.json
@@ -1,1 +1,1 @@
-{"using":["urn:ietf:params:jmap:mail"],"methodCalls":[["EmailSubmission/set",{"onSuccessUpdateEmail":{"#es0":{"keywords/$draft":null,"mailboxIds/MB3":true}},"create":{"es0":{"identityId":"I0","emailId":"M1234"}}},"0"]]}
+{"using":["urn:ietf:params:jmap:mail"],"methodCalls":[["EmailSubmission/set",{"onSuccessUpdateEmail":{"#es0":{"keywords/$draft":null,"mailboxIds/MB3":true}},"accountId":"accountId","create":{"es0":{"identityId":"I0","emailId":"M1234"}}},"0"]]}

--- a/jmap-gson/src/test/resources/request/set-email.json
+++ b/jmap-gson/src/test/resources/request/set-email.json
@@ -1,1 +1,1 @@
-{"using":["urn:ietf:params:jmap:mail"],"methodCalls":[["Email/set",{"ifInState":"state","update":{"M123":{"keywords/$seen":null}}},"0"]]}
+{"using":["urn:ietf:params:jmap:mail"],"methodCalls":[["Email/set",{"accountId":"accountId","ifInState":"state","update":{"M123":{"keywords/$seen":null}}},"0"]]}

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
@@ -32,14 +32,16 @@ import rs.ltt.jmap.common.method.call.thread.GetThreadMethodCall;
 
 public class UpdateUtil {
 
-    public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String state) {
+    public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String accountId, String state) {
         final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesEmailMethodCall(state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetEmailMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED),
                 true
         )).getMethodResponses();
         final ListenableFuture<MethodResponses> updated = multiCall.call(new GetEmailMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
                 true
         )).getMethodResponses();
@@ -47,26 +49,30 @@ public class UpdateUtil {
         return new MethodResponsesFuture(changes, created, updated);
     }
 
-    public static MethodResponsesFuture identities(JmapClient.MultiCall multiCall, String state) {
+    public static MethodResponsesFuture identities(JmapClient.MultiCall multiCall, String accountId, String state) {
         final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesIdentityMethodCall(state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetIdentityMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
         )).getMethodResponses();
         final ListenableFuture<MethodResponses> updated = multiCall.call(new GetIdentityMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
         )).getMethodResponses();
 
         return new MethodResponsesFuture(changes, created, updated);
     }
 
-    public static MethodResponsesFuture mailboxes(JmapClient.MultiCall multiCall, String state) {
+    public static MethodResponsesFuture mailboxes(JmapClient.MultiCall multiCall, String accountId, String state) {
         final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesMailboxMethodCall(state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetMailboxMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
         )).getMethodResponses();
         final ListenableFuture<MethodResponses> updated = multiCall.call(new GetMailboxMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED_PROPERTIES)
         )).getMethodResponses();
@@ -74,13 +80,15 @@ public class UpdateUtil {
         return new MethodResponsesFuture(changes, created, updated);
     }
 
-    public static MethodResponsesFuture threads(JmapClient.MultiCall multiCall, String state) {
+    public static MethodResponsesFuture threads(JmapClient.MultiCall multiCall, String accountId, String state) {
         final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesThreadMethodCall(state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetThreadMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
         )).getMethodResponses();
         final ListenableFuture<MethodResponses> updated = multiCall.call(new GetThreadMethodCall(
+                accountId,
                 changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
         )).getMethodResponses();
 

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
@@ -33,7 +33,7 @@ import rs.ltt.jmap.common.method.call.thread.GetThreadMethodCall;
 public class UpdateUtil {
 
     public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesEmailMethodCall(state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesEmailMethodCall(accountId, state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetEmailMethodCall(
                 accountId,
@@ -50,7 +50,7 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture identities(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesIdentityMethodCall(state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesIdentityMethodCall(accountId, state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetIdentityMethodCall(
                 accountId,
@@ -65,7 +65,7 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture mailboxes(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesMailboxMethodCall(state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesMailboxMethodCall(accountId, state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetMailboxMethodCall(
                 accountId,
@@ -81,7 +81,7 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture threads(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesThreadMethodCall(state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesThreadMethodCall(accountId, state));
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetThreadMethodCall(
                 accountId,

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -1339,7 +1339,7 @@ public class Mua {
 
         final List<ListenableFuture<Status>> piggyBackedFuturesList = piggyBack(queryStateWrapper.objectsState, multiCall);
 
-        final Call queryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(queryStateWrapper.queryState, query)); //TODO do we want to include upTo?
+        final Call queryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(accountId, queryStateWrapper.queryState, query)); //TODO do we want to include upTo?
         final ListenableFuture<MethodResponses> queryChangesResponsesFuture = queryChangesCall.getMethodResponses();
         final ListenableFuture<MethodResponses> getThreadIdResponsesFuture = multiCall.call(new GetEmailMethodCall(accountId, queryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS), new String[]{"threadId"})).getMethodResponses();
 

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -1108,7 +1108,7 @@ public class Mua {
     public ListenableFuture<Boolean> emptyTrash(@NonNullDecl IdentifiableMailboxWithRole trash) {
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
         final EmailFilterCondition filter = EmailFilterCondition.builder().inMailbox(trash.getId()).build();
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(filter));
+        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, filter));
         final ListenableFuture<MethodResponses> setFuture = multiCall.call(new SetEmailMethodCall(accountId, null, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
         multiCall.execute();
         return Futures.transformAsync(setFuture, new AsyncFunction<MethodResponses, Boolean>() {
@@ -1264,7 +1264,7 @@ public class Mua {
         JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
         final ListenableFuture<Status> queryRefreshFuture = refreshQuery(query, queryStateWrapper, multiCall);
 
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(query, afterEmailId, this.queryPageSize));
+        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, query, afterEmailId, this.queryPageSize));
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final ListenableFuture<MethodResponses> getThreadIdsResponsesFuture = multiCall.call(new GetEmailMethodCall(accountId, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS), new String[]{"threadId"})).getMethodResponses();
 
@@ -1394,7 +1394,7 @@ public class Mua {
         //these need to be processed *before* the Query call or else the fetchMissing will not honor newly fetched ids
         final List<ListenableFuture<Status>> piggyBackedFuturesList = piggyBack(queryStateWrapper.objectsState, multiCall);
 
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(query, this.queryPageSize));
+        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, query, this.queryPageSize));
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final Call threadIdsCall = multiCall.call(new GetEmailMethodCall(accountId, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS), new String[]{"threadId"}));
         final ListenableFuture<MethodResponses> getThreadIdsResponsesFuture = threadIdsCall.getMethodResponses();

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -323,7 +323,7 @@ public class Mua {
         if (!email.getKeywords().containsKey(Keyword.SEEN)) {
             emailBuilder.keyword(Keyword.SEEN, true);
         }
-        final ListenableFuture<MethodResponses> future = multiCall.call(new SetEmailMethodCall(ImmutableMap.of("e0", emailBuilder.build()))).getMethodResponses();
+        final ListenableFuture<MethodResponses> future = multiCall.call(new SetEmailMethodCall(accountId, ImmutableMap.of("e0", emailBuilder.build()))).getMethodResponses();
         return Futures.transformAsync(future, new AsyncFunction<MethodResponses, Boolean>() {
             @Override
             public ListenableFuture<Boolean> apply(@NullableDecl MethodResponses methodResponses) throws Exception {
@@ -425,6 +425,7 @@ public class Mua {
             patchesBuilder.remove("mailboxIds/" + draftMailboxId);
         }
         final ListenableFuture<MethodResponses> setEmailSubmissionFuture = multiCall.call(new SetEmailSubmissionMethodCall(
+                accountId,
                 ImmutableMap.of(
                         "es0",
                         EmailSubmission.builder()
@@ -562,7 +563,7 @@ public class Mua {
         if (ifInState) {
             Preconditions.checkNotNull(objectsState);
         }
-        final ListenableFuture<MethodResponses> future = multiCall.call(new SetEmailMethodCall(ifInState ? objectsState.emailState : null, patches)).getMethodResponses();
+        final ListenableFuture<MethodResponses> future = multiCall.call(new SetEmailMethodCall(accountId, ifInState ? objectsState.emailState : null, patches)).getMethodResponses();
         if (ifInState && objectsState.emailState != null) {
             updateEmails(objectsState.emailState, multiCall);
         }
@@ -621,7 +622,7 @@ public class Mua {
     }
 
     public ListenableFuture<Boolean> createMailbox(Mailbox mailbox) {
-        ListenableFuture<MethodResponses> future = jmapClient.call(new SetMailboxMethodCall(ImmutableMap.of("new-mailbox-0", mailbox)));
+        ListenableFuture<MethodResponses> future = jmapClient.call(new SetMailboxMethodCall(accountId, ImmutableMap.of("new-mailbox-0", mailbox)));
         return Futures.transformAsync(future, new AsyncFunction<MethodResponses, Boolean>() {
             @Override
             public ListenableFuture<Boolean> apply(@NullableDecl MethodResponses methodResponses) throws Exception {
@@ -1108,7 +1109,7 @@ public class Mua {
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
         final EmailFilterCondition filter = EmailFilterCondition.builder().inMailbox(trash.getId()).build();
         final Call queryCall = multiCall.call(new QueryEmailMethodCall(filter));
-        final ListenableFuture<MethodResponses> setFuture = multiCall.call(new SetEmailMethodCall(null, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
+        final ListenableFuture<MethodResponses> setFuture = multiCall.call(new SetEmailMethodCall(accountId, null, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
         multiCall.execute();
         return Futures.transformAsync(setFuture, new AsyncFunction<MethodResponses, Boolean>() {
             @Override

--- a/lttrs-cli/src/main/java/rs/ltt/cli/Main.java
+++ b/lttrs-cli/src/main/java/rs/ltt/cli/Main.java
@@ -33,9 +33,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rs.ltt.cli.cache.MyInMemoryCache;
 import rs.ltt.cli.model.QueryViewItem;
+import rs.ltt.jmap.client.JmapClient;
 import rs.ltt.jmap.client.api.MethodErrorResponseException;
 import rs.ltt.jmap.client.api.UnauthorizedException;
 import rs.ltt.jmap.common.entity.*;
+import rs.ltt.jmap.common.entity.capability.MailAccountCapability;
+import rs.ltt.jmap.common.entity.capability.MailCapability;
 import rs.ltt.jmap.common.entity.filter.EmailFilterCondition;
 import rs.ltt.jmap.common.entity.query.EmailQuery;
 import rs.ltt.jmap.mua.Mua;
@@ -77,7 +80,25 @@ public class Main {
 
         final String username = args[0];
         final String password = args[1];
-        final Mua mua = Mua.builder().username(username).password(password).cache(myInMemoryCache).queryPageSize(10).build();
+
+        final String accountId;
+        try {
+            JmapClient jmapClient = new JmapClient(username, password);
+            accountId = jmapClient.getSession().get().getPrimaryAccount(MailAccountCapability.class);
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println("Could not find primary email account");
+            System.exit(1);
+            return;
+        }
+
+        final Mua mua = Mua.builder()
+                .username(username)
+                .password(password)
+                .accountId(accountId)
+                .cache(myInMemoryCache)
+                .queryPageSize(10)
+                .build();
 
         DefaultTerminalFactory defaultTerminalFactory = new DefaultTerminalFactory();
         try {


### PR DESCRIPTION
I'm not sure about the API. But we have to do something similar to this in order to supply the mandatory `accountId` property to JMAP method calls.

@iNPUTmice: What do you think?