### PR TITLE
Fix type of "bodyStructure" field in 'Email'

### DIFF
--- a/jmap-common/src/main/java/rs/ltt/jmap/common/entity/Email.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/entity/Email.java
@@ -98,8 +98,7 @@ public class Email extends AbstractIdentifiableEntity implements IdentifiableEma
 
     //body data
 
-    @Singular("bodyStructure")
-    private List<EmailBodyPart> bodyStructure;
+    private EmailBodyPart bodyStructure;
 
     @Singular
     private Map<String, EmailBodyValue> bodyValues;


### PR DESCRIPTION
See <https://tools.ietf.org/html/rfc8621#section-4.1.4>:
> bodyStructure: "EmailBodyPart" (immutable)

`bodyStructure` is a single `EmailBodyPart`, not a list of them.