### PR TITLE
Use builders for MethodCall implementations

### DIFF
--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -76,7 +76,7 @@ public class Main {
                     EmailFilterCondition.builder().text("test").build()
             );
 
-            Call emailQueryCall = multiCall.call(new QueryEmailMethodCall(accountId, emailFilter));
+            Call emailQueryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).filter(emailFilter).build());
             Future<MethodResponses> emailQueryResponseFuture = emailQueryCall.getMethodResponses();
 
             Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -98,7 +98,13 @@ public class Main {
                 Thread.sleep(5000);
                 final JmapClient.MultiCall updateMultiCall = client.newMultiCall();
 
-                Call emailQueryChangesCall = updateMultiCall.call(new QueryChangesEmailMethodCall(accountId, currentState, emailFilter));
+                Call emailQueryChangesCall = updateMultiCall.call(
+                        QueryChangesEmailMethodCall.builder()
+                                .accountId(accountId)
+                                .sinceQueryState(currentState)
+                                .filter(emailFilter)
+                                .build()
+                );
                 Future<MethodResponses> emailQueryChangesResponseFuture = emailQueryChangesCall.getMethodResponses();
 
                 Future<MethodResponses> emailGetAddedResponseFuture = updateMultiCall.call(new GetEmailMethodCall(accountId, emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))).getMethodResponses();

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -84,7 +84,12 @@ public class Main {
             );
             Future<MethodResponses> emailQueryResponseFuture = emailQueryCall.getMethodResponses();
 
-            Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
+            Future<MethodResponses> emailGetResponseFuture = multiCall.call(
+                    GetEmailMethodCall.builder()
+                            .accountId(accountId)
+                            .idsReference(emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))
+                            .build()
+            ).getMethodResponses();
 
             multiCall.execute();
             final QueryEmailMethodResponse emailQueryResponse = emailQueryResponseFuture.get().getMain(QueryEmailMethodResponse.class);
@@ -107,7 +112,12 @@ public class Main {
                 );
                 Future<MethodResponses> emailQueryChangesResponseFuture = emailQueryChangesCall.getMethodResponses();
 
-                Future<MethodResponses> emailGetAddedResponseFuture = updateMultiCall.call(new GetEmailMethodCall(accountId, emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))).getMethodResponses();
+                Future<MethodResponses> emailGetAddedResponseFuture = updateMultiCall.call(
+                        GetEmailMethodCall.builder()
+                                .accountId(accountId)
+                                .idsReference(emailQueryChangesCall.createResultReference(Request.Invocation.ResultReference.Path.ADDED_IDS))
+                                .build()
+                ).getMethodResponses();
 
                 updateMultiCall.execute();
                 QueryChangesEmailMethodResponse emailQueryChangesResponse = emailQueryChangesResponseFuture.get().getMain(QueryChangesEmailMethodResponse.class);

--- a/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/Main.java
@@ -76,7 +76,12 @@ public class Main {
                     EmailFilterCondition.builder().text("test").build()
             );
 
-            Call emailQueryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).filter(emailFilter).build());
+            Call emailQueryCall = multiCall.call(
+                    QueryEmailMethodCall.builder()
+                            .accountId(accountId)
+                            .filter(emailFilter)
+                            .build()
+            );
             Future<MethodResponses> emailQueryResponseFuture = emailQueryCall.getMethodResponses();
 
             Future<MethodResponses> emailGetResponseFuture = multiCall.call(new GetEmailMethodCall(accountId, emailQueryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();

--- a/jmap-client/src/test/java/rs/ltt/jmap/client/GetDummyMethodCall.java
+++ b/jmap-client/src/test/java/rs/ltt/jmap/client/GetDummyMethodCall.java
@@ -23,6 +23,6 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 public class GetDummyMethodCall extends GetMethodCall<Dummy> {
 
     public GetDummyMethodCall(String accountId) {
-        super(accountId);
+        super(accountId, null, null, null);
     }
 }

--- a/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
+++ b/jmap-client/src/test/java/rs/ltt/jmap/client/HttpJmapClientTest.java
@@ -71,7 +71,9 @@ public class HttpJmapClientTest {
         );
 
 
-        final ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
+        final ListenableFuture<MethodResponses> future = jmapClient.call(
+                GetMailboxMethodCall.builder().accountId(ACCOUNT_ID).build()
+        );
 
 
         final GetMailboxMethodResponse mailboxResponse = future.get().getMain(GetMailboxMethodResponse.class);
@@ -99,7 +101,9 @@ public class HttpJmapClientTest {
         );
 
 
-        ListenableFuture<MethodResponses> future = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
+        ListenableFuture<MethodResponses> future = jmapClient.call(
+                GetMailboxMethodCall.builder().accountId(ACCOUNT_ID).build()
+        );
 
 
         try {
@@ -129,7 +133,9 @@ public class HttpJmapClientTest {
 
         thrown.expect(ExecutionException.class);
         thrown.expectCause(CoreMatchers.<Throwable>instanceOf(MethodResponseNotFoundException.class));
-        jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID)).get();
+        jmapClient.call(
+                GetMailboxMethodCall.builder().accountId(ACCOUNT_ID).build()
+        ).get();
 
         server.shutdown();
     }
@@ -168,7 +174,9 @@ public class HttpJmapClientTest {
                 server.url(WELL_KNOWN_PATH)
         );
 
-        final ListenableFuture<MethodResponses> mailboxFuture = jmapClient.call(new GetMailboxMethodCall(ACCOUNT_ID));
+        final ListenableFuture<MethodResponses> mailboxFuture = jmapClient.call(
+                GetMailboxMethodCall.builder().accountId(ACCOUNT_ID).build()
+        );
 
         // Wait for result
         mailboxFuture.get();

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/core/GetPushSubscriptionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/core/GetPushSubscriptionMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.core;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.PushSubscription;
@@ -23,15 +24,9 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("PushSubscription/get")
 public class GetPushSubscriptionMethodCall extends GetMethodCall<PushSubscription> {
-    public GetPushSubscriptionMethodCall(String accountId, Request.Invocation.ResultReference idsReference) {
-        super(accountId, idsReference);
-    }
 
-    public GetPushSubscriptionMethodCall(String accountId, String[] ids) {
-        super(accountId, ids);
-    }
-
-    public GetPushSubscriptionMethodCall(String accountId) {
-        super(accountId);
+    @Builder
+    public GetPushSubscriptionMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        super(accountId, ids, properties, idsReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/core/SetPushSubscriptionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/core/SetPushSubscriptionMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.core;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.PushSubscription;
@@ -25,23 +26,11 @@ import java.util.Map;
 
 @JmapMethod("PushSubscription/set")
 public class SetPushSubscriptionMethodCall extends SetMethodCall<PushSubscription> {
-    public SetPushSubscriptionMethodCall(String accountId, String ifInState, Map<String, PushSubscription> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        super(accountId, ifInState, create, update, destroy);
-    }
 
-    public SetPushSubscriptionMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetPushSubscriptionMethodCall(String accountId, String ifInState, Request.Invocation.ResultReference destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetPushSubscriptionMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetPushSubscriptionMethodCall(String accountId, Map<String, PushSubscription> create) {
-        super(accountId, create);
+    @Builder
+    public SetPushSubscriptionMethodCall(String accountId, String ifInState, Map<String, PushSubscription> create,
+                                         Map<String, Map<String, Object>> update, String[] destroy,
+                                         Request.Invocation.ResultReference destroyReference) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/ChangesEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/ChangesEmailMethodCall.java
@@ -16,13 +16,16 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.Email;
 import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Email/changes")
 public class ChangesEmailMethodCall extends ChangesMethodCall<Email> {
-    public ChangesEmailMethodCall(String accountId, String sinceState) {
-        super(accountId, sinceState);
+
+    @Builder
+    public ChangesEmailMethodCall(String accountId, String sinceState, Long maxChanges) {
+        super(accountId, sinceState, maxChanges);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/CopyEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/CopyEmailMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.Email;
 import rs.ltt.jmap.common.method.call.standard.CopyMethodCall;
@@ -25,12 +26,9 @@ import java.util.Map;
 @JmapMethod("Email/copy")
 public class CopyEmailMethodCall extends CopyMethodCall<Email> {
 
-    public CopyEmailMethodCall(String fromAccountId, String accountId, Map<String, Email> create) {
-        super(fromAccountId, accountId, create);
-    }
-
-    public CopyEmailMethodCall(String fromAccountId, String ifFromInState, String accountId, String ifInState, Map<String, Email> create, Boolean onSuccessDestroyOriginal, String destroyFromIfInState) {
+    @Builder
+    public CopyEmailMethodCall(String fromAccountId, String ifFromInState, String accountId, String ifInState,
+                               Map<String, Email> create, Boolean onSuccessDestroyOriginal, String destroyFromIfInState) {
         super(fromAccountId, ifFromInState, accountId, ifInState, create, onSuccessDestroyOriginal, destroyFromIfInState);
     }
-
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
@@ -25,15 +25,19 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 @JmapMethod("Email/get")
 public class GetEmailMethodCall extends GetMethodCall<Email> {
 
+    private String[] bodyProperties;
     private Boolean fetchTextBodyValues;
     private Boolean fetchHTMLBodyValues;
     private Boolean fetchAllBodyValues;
     private Long maxBodyValueBytes;
 
     @Builder
-    public GetEmailMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference,
-                              Boolean fetchTextBodyValues, Boolean fetchHTMLBodyValues, Boolean fetchAllBodyValues, Long maxBodyValueBytes) {
+    public GetEmailMethodCall(String accountId, String[] ids, String[] properties,
+                              Request.Invocation.ResultReference idsReference,
+                              String[] bodyProperties, Boolean fetchTextBodyValues, Boolean fetchHTMLBodyValues,
+                              Boolean fetchAllBodyValues, Long maxBodyValueBytes) {
         super(accountId, ids, properties, idsReference);
+        this.bodyProperties = bodyProperties;
         this.fetchTextBodyValues = fetchTextBodyValues;
         this.fetchHTMLBodyValues = fetchHTMLBodyValues;
         this.fetchAllBodyValues = fetchAllBodyValues;

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/GetEmailMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Email;
@@ -29,31 +30,13 @@ public class GetEmailMethodCall extends GetMethodCall<Email> {
     private Boolean fetchAllBodyValues;
     private Long maxBodyValueBytes;
 
-    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
-        super(accountId, resultReference);
-    }
-
-    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference, boolean fetchTextBodyValues) {
-        super(accountId, resultReference);
+    @Builder
+    public GetEmailMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference,
+                              Boolean fetchTextBodyValues, Boolean fetchHTMLBodyValues, Boolean fetchAllBodyValues, Long maxBodyValueBytes) {
+        super(accountId, ids, properties, idsReference);
         this.fetchTextBodyValues = fetchTextBodyValues;
-    }
-
-    public GetEmailMethodCall(String accountId, String[] ids) {
-        super(accountId, ids);
-    }
-
-    public GetEmailMethodCall(String accountId, String[] ids, boolean fetchTextBodyValues) {
-        super(accountId, ids);
-        this.fetchTextBodyValues = fetchTextBodyValues;
-    }
-
-    public GetEmailMethodCall(String accountId, Request.Invocation.ResultReference resultReference, String[] properties) {
-        super(accountId, resultReference);
-        this.properties = properties;
-    }
-
-    public GetEmailMethodCall(String accountId, String[] ids, String[] properties) {
-        super(accountId, ids);
-        this.properties = properties;
+        this.fetchHTMLBodyValues = fetchHTMLBodyValues;
+        this.fetchAllBodyValues = fetchAllBodyValues;
+        this.maxBodyValueBytes = maxBodyValueBytes;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryChangesEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryChangesEmailMethodCall.java
@@ -16,7 +16,9 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.Email;
 import rs.ltt.jmap.common.entity.query.EmailQuery;
 import rs.ltt.jmap.common.entity.filter.Filter;
@@ -27,16 +29,19 @@ public class QueryChangesEmailMethodCall extends QueryChangesMethodCall<Email> {
 
     private Boolean collapseThreads;
 
-    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState, Filter<Email> filter) {
-        super(accountId, sinceQueryState, filter);
+    @Builder
+    public QueryChangesEmailMethodCall(String accountId, Filter<Email> filter, Comparator[] sort, String sinceQueryState,
+                                       Long maxChanges, String upToId, Boolean calculateTotal, Boolean collapseThreads) {
+        super(accountId, filter, sort, sinceQueryState, maxChanges, upToId, calculateTotal);
+        this.collapseThreads = collapseThreads;
     }
 
-    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState, EmailQuery query) {
-        super(accountId, sinceQueryState, query);
-        this.collapseThreads = query.collapseThreads;
-    }
-
-    public QueryChangesEmailMethodCall(String accountId, String sinceQueryState) {
-        super(accountId, sinceQueryState);
+    public static class QueryChangesEmailMethodCallBuilder {
+        public QueryChangesEmailMethodCallBuilder query(EmailQuery query) {
+            filter(query.filter);
+            sort(query.comparators);
+            collapseThreads(query.collapseThreads);
+            return this;
+        }
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
@@ -16,10 +16,12 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.Email;
-import rs.ltt.jmap.common.entity.query.EmailQuery;
 import rs.ltt.jmap.common.entity.filter.Filter;
+import rs.ltt.jmap.common.entity.query.EmailQuery;
 import rs.ltt.jmap.common.method.call.standard.QueryMethodCall;
 
 @JmapMethod("Email/query")
@@ -27,31 +29,19 @@ public class QueryEmailMethodCall extends QueryMethodCall<Email> {
 
     private Boolean collapseThreads;
 
-    public QueryEmailMethodCall(String accountId) {
-        super(accountId);
+    @Builder
+    public QueryEmailMethodCall(String accountId, Filter<Email> filter, Comparator[] sort, Long position, String anchor,
+                                Long anchorOffset, Long limit, Boolean collapseThreads) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+        this.collapseThreads = collapseThreads;
     }
 
-    public QueryEmailMethodCall(String accountId, Filter<Email> filter) {
-        super(accountId, filter);
-    }
-
-    public QueryEmailMethodCall(String accountId, EmailQuery query) {
-        super(accountId, query);
-        this.collapseThreads = query.collapseThreads;
-    }
-
-    public QueryEmailMethodCall(String accountId, EmailQuery query, Long limit) {
-        super(accountId, query, limit);
-        this.collapseThreads = query.collapseThreads;
-    }
-
-    public QueryEmailMethodCall(String accountId, EmailQuery query, String afterEmailId) {
-        super(accountId, query, afterEmailId);
-        this.collapseThreads = query.collapseThreads;
-    }
-
-    public QueryEmailMethodCall(String accountId, EmailQuery query, String afterEmailId, Long limit) {
-        super(accountId, query, afterEmailId, limit);
-        this.collapseThreads = query.collapseThreads;
+    public static class QueryEmailMethodCallBuilder {
+        public QueryEmailMethodCallBuilder query(EmailQuery query) {
+            this.filter = query.filter;
+            this.sort = query.comparators;
+            this.collapseThreads = query.collapseThreads;
+            return this;
+        }
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
@@ -31,8 +31,8 @@ public class QueryEmailMethodCall extends QueryMethodCall<Email> {
 
     @Builder
     public QueryEmailMethodCall(String accountId, Filter<Email> filter, Comparator[] sort, Long position, String anchor,
-                                Long anchorOffset, Long limit, Boolean collapseThreads) {
-        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+                                Long anchorOffset, Long limit, Boolean collapseThreads, Boolean calculateTotal) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit, calculateTotal);
         this.collapseThreads = collapseThreads;
     }
 

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/QueryEmailMethodCall.java
@@ -38,9 +38,9 @@ public class QueryEmailMethodCall extends QueryMethodCall<Email> {
 
     public static class QueryEmailMethodCallBuilder {
         public QueryEmailMethodCallBuilder query(EmailQuery query) {
-            this.filter = query.filter;
-            this.sort = query.comparators;
-            this.collapseThreads = query.collapseThreads;
+            filter(query.filter);
+            sort(query.comparators);
+            collapseThreads(query.collapseThreads);
             return this;
         }
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/SetEmailMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/email/SetEmailMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.email;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Email;
@@ -23,27 +24,13 @@ import rs.ltt.jmap.common.method.call.standard.SetMethodCall;
 
 import java.util.Map;
 
-
 @JmapMethod("Email/set")
 public class SetEmailMethodCall extends SetMethodCall<Email> {
-    public SetEmailMethodCall(String accountId, String ifInState, Map<String, Email> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        super(accountId, ifInState, create, update, destroy);
-    }
 
-    public SetEmailMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetEmailMethodCall(String accountId, String ifInState, Request.Invocation.ResultReference destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-
-    public SetEmailMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetEmailMethodCall(String accountId, Map<String, Email> create) {
-        super(accountId, create);
+    @Builder
+    public SetEmailMethodCall(String accountId, String ifInState, Map<String, Email> create,
+                              Map<String, Map<String, Object>> update, String[] destroy,
+                              Request.Invocation.ResultReference destroyReference) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/ChangesIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/ChangesIdentityMethodCall.java
@@ -16,13 +16,16 @@
 
 package rs.ltt.jmap.common.method.call.identity;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.Identity;
 import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Identity/changes")
 public class ChangesIdentityMethodCall extends ChangesMethodCall<Identity> {
-    public ChangesIdentityMethodCall(String accountId, String sinceState) {
-        super(accountId, sinceState);
+
+    @Builder
+    public ChangesIdentityMethodCall(String accountId, String sinceState, Long maxChanges) {
+        super(accountId, sinceState, maxChanges);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/GetIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/GetIdentityMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.identity;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Identity;
@@ -24,16 +25,8 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 @JmapMethod("Identity/get")
 public class GetIdentityMethodCall extends GetMethodCall<Identity> {
 
-    public GetIdentityMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
-        super(accountId, resultReference);
+    @Builder
+    public GetIdentityMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        super(accountId, ids, properties, idsReference);
     }
-
-    public GetIdentityMethodCall(String accountId, String[] ids) {
-        super(accountId, ids);
-    }
-
-    public GetIdentityMethodCall(String accountId) {
-        super(accountId);
-    }
-
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/SetIdentityMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/identity/SetIdentityMethodCall.java
@@ -16,7 +16,9 @@
 
 package rs.ltt.jmap.common.method.call.identity;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Identity;
 import rs.ltt.jmap.common.method.call.standard.SetMethodCall;
 
@@ -24,19 +26,11 @@ import java.util.Map;
 
 @JmapMethod("Identity/set")
 public class SetIdentityMethodCall extends SetMethodCall<Identity> {
-    public SetIdentityMethodCall(String accountId, String ifInState, Map<String, Identity> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        super(accountId, ifInState, create, update, destroy);
-    }
 
-    public SetIdentityMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetIdentityMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetIdentityMethodCall(String accountId, Map<String, Identity> create) {
-        super(accountId, create);
+    @Builder
+    public SetIdentityMethodCall(String accountId, String ifInState, Map<String, Identity> create,
+                                 Map<String, Map<String, Object>> update, String[] destroy,
+                                 Request.Invocation.ResultReference destroyReference) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/ChangesMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/ChangesMailboxMethodCall.java
@@ -16,13 +16,16 @@
 
 package rs.ltt.jmap.common.method.call.mailbox;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.Mailbox;
 import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Mailbox/changes")
 public class ChangesMailboxMethodCall extends ChangesMethodCall<Mailbox> {
-    public ChangesMailboxMethodCall(String accountId, String sinceState) {
-        super(accountId, sinceState);
+
+    @Builder
+    public ChangesMailboxMethodCall(String accountId, String sinceState, Long maxChanges) {
+        super(accountId, sinceState, maxChanges);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
@@ -17,6 +17,7 @@
 package rs.ltt.jmap.common.method.call.mailbox;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Mailbox;
@@ -28,20 +29,10 @@ public class GetMailboxMethodCall extends GetMethodCall<Mailbox> {
     @SerializedName("#properties")
     private Request.Invocation.ResultReference propertiesReference;
 
-    public GetMailboxMethodCall(String accountId) {
-        super(accountId);
-    }
-
-    public GetMailboxMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
-        super(accountId, resultReference);
-    }
-
-    public GetMailboxMethodCall(String accountId, Request.Invocation.ResultReference idsReference, Request.Invocation.ResultReference propertiesReference) {
-        super(accountId, idsReference);
+    @Builder
+    public GetMailboxMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference,
+                                Request.Invocation.ResultReference propertiesReference) {
+        super(accountId, ids, properties, idsReference);
         this.propertiesReference = propertiesReference;
-    }
-
-    public GetMailboxMethodCall(String accountId, String[] ids) {
-        super(accountId, ids);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/GetMailboxMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.mailbox;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
@@ -33,6 +34,10 @@ public class GetMailboxMethodCall extends GetMethodCall<Mailbox> {
     public GetMailboxMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference,
                                 Request.Invocation.ResultReference propertiesReference) {
         super(accountId, ids, properties, idsReference);
+        Preconditions.checkArgument(
+                properties == null || propertiesReference == null,
+                "Can't set both 'properties' and 'propertiesReference'"
+        );
         this.propertiesReference = propertiesReference;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryChangesMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryChangesMailboxMethodCall.java
@@ -16,24 +16,28 @@
 
 package rs.ltt.jmap.common.method.call.mailbox;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.Mailbox;
 import rs.ltt.jmap.common.entity.filter.Filter;
-import rs.ltt.jmap.common.entity.query.Query;
+import rs.ltt.jmap.common.entity.query.MailboxQuery;
 import rs.ltt.jmap.common.method.call.standard.QueryChangesMethodCall;
 
 @JmapMethod("Mailbox/queryChanges")
 public class QueryChangesMailboxMethodCall extends QueryChangesMethodCall<Mailbox> {
 
-    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState, Filter<Mailbox> filter) {
-        super(accountId, sinceQueryState, filter);
+    @Builder
+    public QueryChangesMailboxMethodCall(String accountId, Filter<Mailbox> filter, Comparator[] sort,
+                                         String sinceQueryState, Long maxChanges, String upToId, Boolean calculateTotal) {
+        super(accountId, filter, sort, sinceQueryState, maxChanges, upToId, calculateTotal);
     }
 
-    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState, Query<Mailbox> query) {
-        super(accountId, sinceQueryState, query);
-    }
-
-    public QueryChangesMailboxMethodCall(String accountId, String sinceQueryState) {
-        super(accountId, sinceQueryState);
+    public static class QueryChangesMailboxMethodCallBuilder {
+        public QueryChangesMailboxMethodCallBuilder query(MailboxQuery query) {
+            filter(query.filter);
+            sort(query.comparators);
+            return this;
+        }
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
@@ -16,7 +16,10 @@
 
 package rs.ltt.jmap.common.method.call.mailbox;
 
+import lombok.Builder;
+import lombok.NonNull;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.Mailbox;
 import rs.ltt.jmap.common.entity.filter.Filter;
 import rs.ltt.jmap.common.entity.query.MailboxQuery;
@@ -26,35 +29,23 @@ import rs.ltt.jmap.common.method.call.standard.QueryMethodCall;
 public class QueryMailboxMethodCall extends QueryMethodCall<Mailbox> {
 
     private Boolean sortAsTree;
-
     private Boolean filterAsTree;
 
-    public QueryMailboxMethodCall(String accountId, Filter<Mailbox> filter) {
-        super(accountId, filter);
+    @Builder
+    public QueryMailboxMethodCall(@NonNull String accountId, Filter<Mailbox> filter, Comparator[] sort, Long position,
+                                  String anchor, Long anchorOffset, Long limit, Boolean sortAsTree, Boolean filterAsTree) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+        this.sortAsTree = sortAsTree;
+        this.filterAsTree = filterAsTree;
     }
 
-    public QueryMailboxMethodCall(String accountId, MailboxQuery query) {
-        super(accountId, query);
-        this.sortAsTree = query.sortAsTree;
-        this.filterAsTree = query.filterAsTree;
+    public static class QueryMailboxMethodCallBuilder {
+        public QueryMailboxMethodCallBuilder query(MailboxQuery query) {
+            this.filter = query.filter;
+            this.sort = query.comparators;
+            this.sortAsTree = query.sortAsTree;
+            this.filterAsTree = query.filterAsTree;
+            return this;
+        }
     }
-
-    public QueryMailboxMethodCall(String accountId, MailboxQuery query, String afterId) {
-        super(accountId, query, afterId);
-        this.sortAsTree = query.sortAsTree;
-        this.filterAsTree = query.filterAsTree;
-    }
-
-    public QueryMailboxMethodCall(String accountId, MailboxQuery query, Long limit) {
-        super(accountId, query, limit);
-        this.sortAsTree = query.sortAsTree;
-        this.filterAsTree = query.filterAsTree;
-    }
-
-    public QueryMailboxMethodCall(String accountId, MailboxQuery query, String afterId, Long limit) {
-        super(accountId, query, afterId, limit);
-        this.sortAsTree = query.sortAsTree;
-        this.filterAsTree = query.filterAsTree;
-    }
-
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
@@ -41,10 +41,10 @@ public class QueryMailboxMethodCall extends QueryMethodCall<Mailbox> {
 
     public static class QueryMailboxMethodCallBuilder {
         public QueryMailboxMethodCallBuilder query(MailboxQuery query) {
-            this.filter = query.filter;
-            this.sort = query.comparators;
-            this.sortAsTree = query.sortAsTree;
-            this.filterAsTree = query.filterAsTree;
+            filter(query.filter);
+            sort(query.comparators);
+            sortAsTree(query.sortAsTree);
+            filterAsTree(query.filterAsTree);
             return this;
         }
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/QueryMailboxMethodCall.java
@@ -33,8 +33,9 @@ public class QueryMailboxMethodCall extends QueryMethodCall<Mailbox> {
 
     @Builder
     public QueryMailboxMethodCall(@NonNull String accountId, Filter<Mailbox> filter, Comparator[] sort, Long position,
-                                  String anchor, Long anchorOffset, Long limit, Boolean sortAsTree, Boolean filterAsTree) {
-        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+                                  String anchor, Long anchorOffset, Long limit, Boolean sortAsTree, Boolean filterAsTree,
+                                  Boolean calculateTotal) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit, calculateTotal);
         this.sortAsTree = sortAsTree;
         this.filterAsTree = filterAsTree;
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/SetMailboxMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/mailbox/SetMailboxMethodCall.java
@@ -16,7 +16,9 @@
 
 package rs.ltt.jmap.common.method.call.mailbox;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Mailbox;
 import rs.ltt.jmap.common.method.call.standard.SetMethodCall;
 
@@ -27,29 +29,11 @@ public class SetMailboxMethodCall extends SetMethodCall<Mailbox> {
 
     private Boolean onDestroyRemoveEmails;
 
-    public SetMailboxMethodCall(String accountId, String ifInState, Map<String, Mailbox> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        super(accountId, ifInState, create, update, destroy);
-    }
-
-    public SetMailboxMethodCall(String accountId, String ifInState, Map<String, Mailbox> create, Map<String, Map<String, Object>> update, String[] destroy, Boolean onDestroyRemoveEmails) {
-        super(accountId, ifInState, create, update, destroy);
+    @Builder
+    public SetMailboxMethodCall(String accountId, String ifInState, Map<String, Mailbox> create,
+                                Map<String, Map<String, Object>> update, String[] destroy,
+                                Request.Invocation.ResultReference destroyReference, Boolean onDestroyRemoveEmails) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
         this.onDestroyRemoveEmails = onDestroyRemoveEmails;
-    }
-
-    public SetMailboxMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetMailboxMethodCall(String accountId, String ifInState, String[] destroy, Boolean onDestroyRemoveEmails) {
-        super(accountId, ifInState, destroy);
-        this.onDestroyRemoveEmails = onDestroyRemoveEmails;
-    }
-
-    public SetMailboxMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetMailboxMethodCall(String accountId, Map<String, Mailbox> create) {
-        super(accountId, create);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.snippet;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
 import lombok.NonNull;
@@ -40,6 +41,7 @@ public class GetSearchSnippetsMethodCall implements MethodCall {
 
     @Builder
     public GetSearchSnippetsMethodCall(String accountId, String[] ids, Filter filter, Request.Invocation.ResultReference idsReference) {
+        Preconditions.checkArgument(ids == null || idsReference == null, "Can't set both 'ids' and 'idsReference'");
         this.accountId = accountId;
         this.ids = ids;
         this.filter = filter;

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
@@ -17,6 +17,7 @@
 package rs.ltt.jmap.common.method.call.snippet;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Email;
@@ -34,16 +35,11 @@ public class GetSearchSnippetsMethodCall implements MethodCall {
     @SerializedName("#ids")
     private Request.Invocation.ResultReference idsReference;
 
-    public GetSearchSnippetsMethodCall(String accountId, Request.Invocation.ResultReference idsReference, Filter<Email> filter) {
-        this.accountId = accountId;
-        this.idsReference = idsReference;
-        this.filter = filter;
-    }
-
-    public GetSearchSnippetsMethodCall(String accountId, String[] ids, Filter<Email> filter) {
+    @Builder
+    public GetSearchSnippetsMethodCall(String accountId, String[] ids, Filter filter, Request.Invocation.ResultReference idsReference) {
         this.accountId = accountId;
         this.ids = ids;
         this.filter = filter;
+        this.idsReference = idsReference;
     }
-
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
@@ -18,6 +18,7 @@ package rs.ltt.jmap.common.method.call.snippet;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.Builder;
+import lombok.NonNull;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Email;
@@ -27,9 +28,11 @@ import rs.ltt.jmap.common.method.MethodCall;
 @JmapMethod("SearchSnippet/get")
 public class GetSearchSnippetsMethodCall implements MethodCall {
 
-
+    @NonNull
     private String accountId;
+
     private String[] ids;
+
     private Filter filter;
 
     @SerializedName("#ids")

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/snippet/GetSearchSnippetsMethodCall.java
@@ -32,19 +32,23 @@ public class GetSearchSnippetsMethodCall implements MethodCall {
     @NonNull
     private String accountId;
 
-    private String[] ids;
-
     private Filter filter;
 
-    @SerializedName("#ids")
-    private Request.Invocation.ResultReference idsReference;
+    private String[] emailIds;
+
+    @SerializedName("#emailIds")
+    private Request.Invocation.ResultReference emailIdsReference;
 
     @Builder
-    public GetSearchSnippetsMethodCall(String accountId, String[] ids, Filter filter, Request.Invocation.ResultReference idsReference) {
-        Preconditions.checkArgument(ids == null || idsReference == null, "Can't set both 'ids' and 'idsReference'");
+    public GetSearchSnippetsMethodCall(String accountId, String[] emailIds, Filter<Email> filter,
+                                       Request.Invocation.ResultReference emailIdsReference) {
+        Preconditions.checkArgument(
+                emailIds == null || emailIdsReference == null,
+                "Can't set both 'emailIds' and 'emailIdsReference'"
+        );
         this.accountId = accountId;
-        this.ids = ids;
+        this.emailIds = emailIds;
         this.filter = filter;
-        this.idsReference = idsReference;
+        this.emailIdsReference = emailIdsReference;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
@@ -16,18 +16,15 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import lombok.AllArgsConstructor;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
+@AllArgsConstructor
 public abstract class ChangesMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     private String accountId;
     private String sinceState;
     private Long maxChanges;
-
-    public ChangesMethodCall(String accountId, String sinceState) {
-        this.accountId = accountId;
-        this.sinceState = sinceState;
-    }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/ChangesMethodCall.java
@@ -17,14 +17,19 @@
 package rs.ltt.jmap.common.method.call.standard;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
 @AllArgsConstructor
 public abstract class ChangesMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String accountId;
+
+    @NonNull
     private String sinceState;
+
     private Long maxChanges;
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/CopyMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/CopyMethodCall.java
@@ -16,41 +16,21 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import lombok.AllArgsConstructor;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
 import java.util.Map;
 
+@AllArgsConstructor
 public abstract class CopyMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     private String fromAccountId;
-
     private String ifFromInState;
-
     private String accountId;
-
     private String ifInState;
-
     private Map<String, T> create;
-
     private Boolean onSuccessDestroyOriginal;
-
     private String destroyFromIfInState;
-
-    protected CopyMethodCall(String fromAccountId, String accountId, Map<String, T> create) {
-        this.fromAccountId = fromAccountId;
-        this.accountId = accountId;
-        this.create = create;
-    }
-
-    protected CopyMethodCall(String fromAccountId, String ifFromInState, String accountId, String ifInState, Map<String, T> create, Boolean onSuccessDestroyOriginal, String destroyFromIfInState) {
-        this.fromAccountId = fromAccountId;
-        this.ifFromInState = ifFromInState;
-        this.accountId = accountId;
-        this.ifInState = ifInState;
-        this.create = create;
-        this.onSuccessDestroyOriginal = onSuccessDestroyOriginal;
-        this.destroyFromIfInState = destroyFromIfInState;
-    }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/CopyMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/CopyMethodCall.java
@@ -17,6 +17,7 @@
 package rs.ltt.jmap.common.method.call.standard;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
@@ -25,12 +26,21 @@ import java.util.Map;
 @AllArgsConstructor
 public abstract class CopyMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String fromAccountId;
+
     private String ifFromInState;
+
+    @NonNull
     private String accountId;
+
     private String ifInState;
+
+    @NonNull
     private Map<String, T> create;
+
     private Boolean onSuccessDestroyOriginal;
+
     private String destroyFromIfInState;
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
@@ -23,7 +24,6 @@ import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
-@AllArgsConstructor
 public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     @NonNull
@@ -36,4 +36,11 @@ public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implem
     @SerializedName("#ids")
     private Request.Invocation.ResultReference idsReference;
 
+    public GetMethodCall(@NonNull String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        Preconditions.checkArgument(ids == null || idsReference == null, "Can't set both 'ids' and 'idsReference'");
+        this.accountId = accountId;
+        this.ids = ids;
+        this.properties = properties;
+        this.idsReference = idsReference;
+    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
@@ -17,10 +17,12 @@
 package rs.ltt.jmap.common.method.call.standard;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
+@AllArgsConstructor
 public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     private String accountId;
@@ -29,20 +31,5 @@ public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implem
 
     @SerializedName("#ids")
     private Request.Invocation.ResultReference idsReference;
-
-    public GetMethodCall(String accountId, Request.Invocation.ResultReference idsReference) {
-        this.accountId = accountId;
-        this.idsReference = idsReference;
-    }
-
-
-    public GetMethodCall(String accountId, String[] ids) {
-        this.accountId = accountId;
-        this.ids = ids;
-    }
-
-    public GetMethodCall(String accountId) {
-        this.accountId = accountId;
-    }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/GetMethodCall.java
@@ -18,6 +18,7 @@ package rs.ltt.jmap.common.method.call.standard;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
@@ -25,8 +26,11 @@ import rs.ltt.jmap.common.method.MethodCall;
 @AllArgsConstructor
 public abstract class GetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String accountId;
+
     private String[] ids;
+
     protected String[] properties;
 
     @SerializedName("#ids")

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
@@ -16,12 +16,13 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import lombok.AllArgsConstructor;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.entity.Comparator;
-import rs.ltt.jmap.common.entity.query.Query;
 import rs.ltt.jmap.common.entity.filter.Filter;
 import rs.ltt.jmap.common.method.MethodCall;
 
+@AllArgsConstructor
 public abstract class QueryChangesMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     private String accountId;
@@ -31,23 +32,5 @@ public abstract class QueryChangesMethodCall<T extends AbstractIdentifiableEntit
     private Long maxChanges;
     private String upToId;
     private Boolean calculateTotal;
-
-    public QueryChangesMethodCall(String accountId, String sinceQueryState, final Filter<T> filter) {
-        this.accountId = accountId;
-        this.sinceQueryState = sinceQueryState;
-        this.filter = filter;
-    }
-
-    public QueryChangesMethodCall(String accountId, String sinceQueryState, final Query<T> query) {
-        this.accountId = accountId;
-        this.sinceQueryState = sinceQueryState;
-        this.filter = query.filter;
-        this.sort = query.comparators;
-    }
-
-    public QueryChangesMethodCall(String accountId, String sinceQueryState) {
-        this.accountId = accountId;
-        this.sinceQueryState = sinceQueryState;
-    }
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryChangesMethodCall.java
@@ -17,6 +17,7 @@
 package rs.ltt.jmap.common.method.call.standard;
 
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.filter.Filter;
@@ -25,12 +26,20 @@ import rs.ltt.jmap.common.method.MethodCall;
 @AllArgsConstructor
 public abstract class QueryChangesMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String accountId;
+
     private Filter filter;
+
     private Comparator[] sort;
+
+    @NonNull
     private String sinceQueryState;
+
     private Long maxChanges;
+
     private String upToId;
+
     private Boolean calculateTotal;
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
@@ -26,11 +26,17 @@ public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> impl
 
     @NonNull
     private String accountId;
+
     private Filter filter;
+
     private Comparator[] sort;
+
     private Long position;
+
     private String anchor;
+
     private Long anchorOffset;
+
     private Long limit;
 
     public QueryMethodCall(@NonNull String accountId, Filter<T> filter, Comparator[] sort, Long position, String anchor,

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
@@ -16,15 +16,15 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import lombok.NonNull;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.entity.Comparator;
-import rs.ltt.jmap.common.entity.query.Query;
 import rs.ltt.jmap.common.entity.filter.Filter;
 import rs.ltt.jmap.common.method.MethodCall;
 
-
 public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String accountId;
     private Filter filter;
     private Comparator[] sort;
@@ -33,43 +33,18 @@ public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> impl
     private Long anchorOffset;
     private Long limit;
 
-    public QueryMethodCall(String accountId) {
-        this.accountId = accountId;
-    }
-
-    public QueryMethodCall(String accountId, Filter<T> filter) {
+    public QueryMethodCall(@NonNull String accountId, Filter<T> filter, Comparator[] sort, Long position, String anchor,
+                           Long anchorOffset, Long limit) {
         this.accountId = accountId;
         this.filter = filter;
-    }
-
-    public QueryMethodCall(String accountId, Query<T> query) {
-        this.accountId = accountId;
-        this.filter = query.filter;
-        this.sort = query.comparators;
-    }
-
-    public QueryMethodCall(String accountId, Query<T> query, Long limit) {
-        this.accountId = accountId;
-        this.filter = query.filter;
-        this.sort = query.comparators;
+        this.sort = sort;
+        this.position = position;
+        this.anchor = anchor;
+        if (anchor != null) {
+            this.anchorOffset = (anchorOffset != null) ? anchorOffset : 1L;
+        } else {
+            this.anchorOffset = null;
+        }
         this.limit = limit;
     }
-
-    public QueryMethodCall(String accountId, Query<T> query, String afterId) {
-        this.accountId = accountId;
-        this.filter = query.filter;
-        this.sort = query.comparators;
-        this.anchor = afterId;
-        this.anchorOffset = 1L;
-    }
-
-    public QueryMethodCall(String accountId, Query<T> query, String afterId, Long limit) {
-        this.accountId = accountId;
-        this.filter = query.filter;
-        this.sort = query.comparators;
-        this.anchor = afterId;
-        this.anchorOffset = 1L;
-        this.limit = limit;
-    }
-
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/QueryMethodCall.java
@@ -39,8 +39,10 @@ public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> impl
 
     private Long limit;
 
+    private Boolean calculateTotal;
+
     public QueryMethodCall(@NonNull String accountId, Filter<T> filter, Comparator[] sort, Long position, String anchor,
-                           Long anchorOffset, Long limit) {
+                           Long anchorOffset, Long limit, Boolean calculateTotal) {
         this.accountId = accountId;
         this.filter = filter;
         this.sort = sort;
@@ -52,5 +54,6 @@ public abstract class QueryMethodCall<T extends AbstractIdentifiableEntity> impl
             this.anchorOffset = null;
         }
         this.limit = limit;
+        this.calculateTotal = calculateTotal;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
@@ -17,55 +17,24 @@
 package rs.ltt.jmap.common.method.call.standard;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
 
 import java.util.Map;
 
+@AllArgsConstructor
 public abstract class SetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     private String accountId;
-
     private String ifInState;
-
     private Map<String, T> create;
-
     private Map<String, Map<String, Object>> update;
-
     private String[] destroy;
 
     @SerializedName("#destroy")
     private Request.Invocation.ResultReference destroyReference;
 
-    public SetMethodCall(String accountId, String ifInState, Map<String, T> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        this.accountId = accountId;
-        this.ifInState = ifInState;
-        this.create = create;
-        this.update = update;
-        this.destroy = destroy;
-    }
 
-    public SetMethodCall(String accountId, String ifInState, String[] destroy) {
-        this.accountId = accountId;
-        this.ifInState = ifInState;
-        this.destroy = destroy;
-    }
-
-    public SetMethodCall(String accountId, String ifInState, Request.Invocation.ResultReference destroy) {
-        this.accountId = accountId;
-        this.ifInState = ifInState;
-        this.destroyReference = destroy;
-    }
-
-    public SetMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        this.accountId = accountId;
-        this.ifInState = ifInState;
-        this.update = update;
-    }
-
-    public SetMethodCall(String accountId, Map<String, T> create) {
-        this.accountId = accountId;
-        this.create = create;
-    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.standard;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
@@ -25,7 +26,6 @@ import rs.ltt.jmap.common.method.MethodCall;
 
 import java.util.Map;
 
-@AllArgsConstructor
 public abstract class SetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
     @NonNull
@@ -42,4 +42,18 @@ public abstract class SetMethodCall<T extends AbstractIdentifiableEntity> implem
     @SerializedName("#destroy")
     private Request.Invocation.ResultReference destroyReference;
 
+    public SetMethodCall(@NonNull String accountId, String ifInState, Map<String, T> create,
+                         Map<String, Map<String, Object>> update, String[] destroy,
+                         Request.Invocation.ResultReference destroyReference) {
+        Preconditions.checkArgument(
+                destroy == null || destroyReference == null,
+                "Can't set both 'destroy' and 'destroyReference'"
+        );
+        this.accountId = accountId;
+        this.ifInState = ifInState;
+        this.create = create;
+        this.update = update;
+        this.destroy = destroy;
+        this.destroyReference = destroyReference;
+    }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/standard/SetMethodCall.java
@@ -18,6 +18,7 @@ package rs.ltt.jmap.common.method.call.standard;
 
 import com.google.gson.annotations.SerializedName;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.AbstractIdentifiableEntity;
 import rs.ltt.jmap.common.method.MethodCall;
@@ -27,14 +28,18 @@ import java.util.Map;
 @AllArgsConstructor
 public abstract class SetMethodCall<T extends AbstractIdentifiableEntity> implements MethodCall {
 
+    @NonNull
     private String accountId;
+
     private String ifInState;
+
     private Map<String, T> create;
+
     private Map<String, Map<String, Object>> update;
+
     private String[] destroy;
 
     @SerializedName("#destroy")
     private Request.Invocation.ResultReference destroyReference;
-
 
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/ChangesEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/ChangesEmailSubmissionMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.submission;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.EmailSubmission;
 import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
@@ -23,7 +24,8 @@ import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 @JmapMethod("EmailSubmission/changes")
 public class ChangesEmailSubmissionMethodCall extends ChangesMethodCall<EmailSubmission> {
 
-    public ChangesEmailSubmissionMethodCall(String accountId, String sinceState) {
-        super(accountId, sinceState);
+    @Builder
+    public ChangesEmailSubmissionMethodCall(String accountId, String sinceState, Long maxChanges) {
+        super(accountId, sinceState, maxChanges);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/GetEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/GetEmailSubmissionMethodCall.java
@@ -16,13 +16,17 @@
 
 package rs.ltt.jmap.common.method.call.submission;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.EmailSubmission;
 import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("EmailSubmission/get")
 public class GetEmailSubmissionMethodCall extends GetMethodCall<EmailSubmission> {
-    public GetEmailSubmissionMethodCall(String accountId) {
-        super(accountId);
+
+    @Builder
+    public GetEmailSubmissionMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        super(accountId, ids, properties, idsReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryChangesEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryChangesEmailSubmissionMethodCall.java
@@ -16,23 +16,28 @@
 
 package rs.ltt.jmap.common.method.call.submission;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.EmailSubmission;
 import rs.ltt.jmap.common.entity.filter.Filter;
-import rs.ltt.jmap.common.entity.query.Query;
+import rs.ltt.jmap.common.entity.query.EmailSubmissionQuery;
 import rs.ltt.jmap.common.method.call.standard.QueryChangesMethodCall;
 
 @JmapMethod("EmailSubmission/queryChanges")
 public class QueryChangesEmailSubmissionMethodCall extends QueryChangesMethodCall<EmailSubmission> {
-    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState, Filter<EmailSubmission> filter) {
-        super(accountId, sinceQueryState, filter);
+
+    @Builder
+    public QueryChangesEmailSubmissionMethodCall(String accountId, Filter<EmailSubmission> filter, Comparator[] sort,
+                                                 String sinceQueryState, Long maxChanges, String upToId, Boolean calculateTotal) {
+        super(accountId, filter, sort, sinceQueryState, maxChanges, upToId, calculateTotal);
     }
 
-    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState, Query<EmailSubmission> query) {
-        super(accountId, sinceQueryState, query);
-    }
-
-    public QueryChangesEmailSubmissionMethodCall(String accountId, String sinceQueryState) {
-        super(accountId, sinceQueryState);
+    public static class QueryChangesEmailSubmissionMethodCallBuilder {
+        public QueryChangesEmailSubmissionMethodCallBuilder query(EmailSubmissionQuery query) {
+            filter(query.filter);
+            sort(query.comparators);
+            return this;
+        }
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
@@ -36,8 +36,8 @@ public class QueryEmailSubmissionMethodCall extends QueryMethodCall<EmailSubmiss
 
     public static class QueryEmailSubmissionMethodCallBuilder {
         public QueryEmailSubmissionMethodCallBuilder query(EmailSubmissionQuery query) {
-            this.filter = query.filter;
-            this.sort = query.comparators;
+            filter(query.filter);
+            sort(query.comparators);
             return this;
         }
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
@@ -16,13 +16,29 @@
 
 package rs.ltt.jmap.common.method.call.submission;
 
+import lombok.Builder;
+import lombok.NonNull;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.entity.Comparator;
 import rs.ltt.jmap.common.entity.EmailSubmission;
+import rs.ltt.jmap.common.entity.filter.Filter;
+import rs.ltt.jmap.common.entity.query.EmailSubmissionQuery;
 import rs.ltt.jmap.common.method.call.standard.QueryMethodCall;
 
 @JmapMethod("EmailSubmission/query")
 public class QueryEmailSubmissionMethodCall extends QueryMethodCall<EmailSubmission> {
-    public QueryEmailSubmissionMethodCall(String accountId) {
-        super(accountId);
+
+    @Builder
+    public QueryEmailSubmissionMethodCall(@NonNull String accountId, Filter<EmailSubmission> filter, Comparator[] sort,
+                                          Long position, String anchor, Long anchorOffset, Long limit) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+    }
+
+    public static class QueryEmailSubmissionMethodCallBuilder {
+        public QueryEmailSubmissionMethodCallBuilder query(EmailSubmissionQuery query) {
+            this.filter = query.filter;
+            this.sort = query.comparators;
+            return this;
+        }
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/QueryEmailSubmissionMethodCall.java
@@ -30,8 +30,9 @@ public class QueryEmailSubmissionMethodCall extends QueryMethodCall<EmailSubmiss
 
     @Builder
     public QueryEmailSubmissionMethodCall(@NonNull String accountId, Filter<EmailSubmission> filter, Comparator[] sort,
-                                          Long position, String anchor, Long anchorOffset, Long limit) {
-        super(accountId, filter, sort, position, anchor, anchorOffset, limit);
+                                          Long position, String anchor, Long anchorOffset, Long limit,
+                                          Boolean calculateTotal) {
+        super(accountId, filter, sort, position, anchor, anchorOffset, limit, calculateTotal);
     }
 
     public static class QueryEmailSubmissionMethodCallBuilder {

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
@@ -34,6 +34,7 @@ public class SetEmailSubmissionMethodCall extends SetMethodCall<EmailSubmission>
 
     @JmapImplicitNamespace(Namespace.MAIL)
     private Map<String, Map<String, Object>> onSuccessUpdateEmail;
+
     private List<String> onSuccessDestroyEmail;
 
     @Builder

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/submission/SetEmailSubmissionMethodCall.java
@@ -16,10 +16,12 @@
 
 package rs.ltt.jmap.common.method.call.submission;
 
+import lombok.Builder;
 import lombok.Getter;
 import rs.ltt.jmap.Namespace;
 import rs.ltt.jmap.annotation.JmapImplicitNamespace;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.EmailSubmission;
 import rs.ltt.jmap.common.method.call.standard.SetMethodCall;
 
@@ -34,36 +36,14 @@ public class SetEmailSubmissionMethodCall extends SetMethodCall<EmailSubmission>
     private Map<String, Map<String, Object>> onSuccessUpdateEmail;
     private List<String> onSuccessDestroyEmail;
 
-    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, EmailSubmission> create, Map<String, Map<String, Object>> update, String[] destroy, Map<String, Map<String, Object>> onSuccessUpdateEmail, List<String> onSuccessDestroyEmail) {
-        super(accountId, ifInState, create, update, destroy);
+    @Builder
+    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, EmailSubmission> create,
+                                        Map<String, Map<String, Object>> update, String[] destroy,
+                                        Request.Invocation.ResultReference destroyReference,
+                                        Map<String, Map<String, Object>> onSuccessUpdateEmail,
+                                        List<String> onSuccessDestroyEmail) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
         this.onSuccessUpdateEmail = onSuccessUpdateEmail;
         this.onSuccessDestroyEmail = onSuccessDestroyEmail;
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, String ifInState, String[] destroy, List<String> onSuccessDestroyEmail) {
-        super(accountId, ifInState, destroy);
-        this.onSuccessDestroyEmail = onSuccessDestroyEmail;
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
-        super(accountId, ifInState, update);
-        this.onSuccessUpdateEmail = onSuccessUpdateEmail;
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, Map<String, EmailSubmission> create) {
-        super(accountId, create);
-    }
-
-    public SetEmailSubmissionMethodCall(String accountId, Map<String, EmailSubmission> create, Map<String, Map<String, Object>> onSuccessUpdateEmail) {
-        super(accountId, create);
-        this.onSuccessUpdateEmail = onSuccessUpdateEmail;
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/ChangesThreadMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/ChangesThreadMethodCall.java
@@ -16,13 +16,16 @@
 
 package rs.ltt.jmap.common.method.call.thread;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.entity.Thread;
 import rs.ltt.jmap.common.method.call.standard.ChangesMethodCall;
 
 @JmapMethod("Thread/changes")
 public class ChangesThreadMethodCall extends ChangesMethodCall<Thread> {
-    public ChangesThreadMethodCall(String accountId, String sinceState) {
-        super(accountId, sinceState);
+
+    @Builder
+    public ChangesThreadMethodCall(String accountId, String sinceState, Long maxChanges) {
+        super(accountId, sinceState, maxChanges);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/GetThreadMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/thread/GetThreadMethodCall.java
@@ -16,6 +16,7 @@
 
 package rs.ltt.jmap.common.method.call.thread;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
 import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.Thread;
@@ -23,12 +24,9 @@ import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("Thread/get")
 public class GetThreadMethodCall extends GetMethodCall<Thread> {
-    
-    public GetThreadMethodCall(String accountId, Request.Invocation.ResultReference resultReference) {
-        super(accountId, resultReference);
-    }
 
-    public GetThreadMethodCall(String accountId, String[] ids) {
-        super(accountId, ids);
+    @Builder
+    public GetThreadMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        super(accountId, ids, properties, idsReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/GetVacationResponseMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/GetVacationResponseMethodCall.java
@@ -16,13 +16,17 @@
 
 package rs.ltt.jmap.common.method.call.vacation;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.VacationResponse;
 import rs.ltt.jmap.common.method.call.standard.GetMethodCall;
 
 @JmapMethod("VacationResponse/get")
 public class GetVacationResponseMethodCall extends GetMethodCall<VacationResponse> {
-    public GetVacationResponseMethodCall(String accountId) {
-        super(accountId);
+
+    @Builder
+    public GetVacationResponseMethodCall(String accountId, String[] ids, String[] properties, Request.Invocation.ResultReference idsReference) {
+        super(accountId, ids, properties, idsReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/SetVacationResponseMethodCall.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/call/vacation/SetVacationResponseMethodCall.java
@@ -16,7 +16,9 @@
 
 package rs.ltt.jmap.common.method.call.vacation;
 
+import lombok.Builder;
 import rs.ltt.jmap.annotation.JmapMethod;
+import rs.ltt.jmap.common.Request;
 import rs.ltt.jmap.common.entity.VacationResponse;
 import rs.ltt.jmap.common.method.call.standard.SetMethodCall;
 
@@ -24,19 +26,11 @@ import java.util.Map;
 
 @JmapMethod("VacationResponse/set")
 public class SetVacationResponseMethodCall extends SetMethodCall<VacationResponse> {
-    public SetVacationResponseMethodCall(String accountId, String ifInState, Map<String, VacationResponse> create, Map<String, Map<String, Object>> update, String[] destroy) {
-        super(accountId, ifInState, create, update, destroy);
-    }
 
-    public SetVacationResponseMethodCall(String accountId, String ifInState, String[] destroy) {
-        super(accountId, ifInState, destroy);
-    }
-
-    public SetVacationResponseMethodCall(String accountId, String ifInState, Map<String, Map<String, Object>> update) {
-        super(accountId, ifInState, update);
-    }
-
-    public SetVacationResponseMethodCall(String accountId, Map<String, VacationResponse> create) {
-        super(accountId, create);
+    @Builder
+    public SetVacationResponseMethodCall(String accountId, String ifInState, Map<String, VacationResponse> create,
+                                         Map<String, Map<String, Object>> update, String[] destroy,
+                                         Request.Invocation.ResultReference destroyReference) {
+        super(accountId, ifInState, create, update, destroy, destroyReference);
     }
 }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/response/snippet/GetSnippetMethodResponse.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/response/snippet/GetSnippetMethodResponse.java
@@ -28,19 +28,16 @@ public class GetSnippetMethodResponse implements MethodResponse {
 
     protected String accountId;
 
-    protected String state;
+    protected SearchSnippet[] list;
 
     protected String[] notFound;
-
-    protected SearchSnippet[] list;
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("accountId", accountId)
-                .add("state", state)
-                .add("notFound", notFound)
                 .add("list", list)
+                .add("notFound", notFound)
                 .toString();
     }
 }

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/CopyEmailMethodCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/CopyEmailMethodCallTest.java
@@ -36,10 +36,11 @@ public class CopyEmailMethodCallTest extends AbstractGsonTest {
         GsonBuilder builder = new GsonBuilder();
         JmapAdapters.register(builder);
         Gson gson = builder.create();
-        CopyEmailMethodCall copyEmailMethodCall = new CopyEmailMethodCall("from@domain.tld",
-                "to@domain.tld",
-                ImmutableMap.of("a", Email.of("M1001"))
-        );
+        CopyEmailMethodCall copyEmailMethodCall = CopyEmailMethodCall.builder()
+                .fromAccountId("from@domain.tld")
+                .accountId("to@domain.tld")
+                .create(ImmutableMap.of("a", Email.of("M1001")))
+                .build();
         Request request = new Request.Builder().call(copyEmailMethodCall).build();
         Assert.assertEquals(readResourceAsString("request/copy-email.json"),gson.toJson(request));
     }

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
@@ -19,7 +19,7 @@ public class QueryCallTest extends AbstractGsonTest {
         JmapAdapters.register(builder);
         Gson gson = builder.create();
         final EmailQuery query = EmailQuery.of(EmailFilterCondition.builder().inMailbox("inbox-id").build(), true);
-        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(new QueryEmailMethodCall("accountId", query)));
+        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(QueryEmailMethodCall.builder().accountId("accountId").query(query).build()));
         Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("accountId", "first", query)));
     }
 

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
@@ -19,7 +19,12 @@ public class QueryCallTest extends AbstractGsonTest {
         JmapAdapters.register(builder);
         Gson gson = builder.create();
         final EmailQuery query = EmailQuery.of(EmailFilterCondition.builder().inMailbox("inbox-id").build(), true);
-        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(QueryEmailMethodCall.builder().accountId("accountId").query(query).build()));
+        Assert.assertEquals(readResourceAsString("request/query-email.json"), gson.toJson(
+                QueryEmailMethodCall.builder()
+                        .accountId("accountId")
+                        .query(query)
+                        .build()
+        ));
         Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("accountId", "first", query)));
     }
 

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/QueryCallTest.java
@@ -25,7 +25,13 @@ public class QueryCallTest extends AbstractGsonTest {
                         .query(query)
                         .build()
         ));
-        Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(new QueryChangesEmailMethodCall("accountId", "first", query)));
+        Assert.assertEquals(readResourceAsString("request/query-changes-email.json"), gson.toJson(
+                QueryChangesEmailMethodCall.builder()
+                        .accountId("accountId")
+                        .sinceQueryState("first")
+                        .query(query)
+                        .build()
+        ));
     }
 
 }

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
@@ -13,7 +13,7 @@ public class ResultReferenceTypeAdapterTest {
 
     @Test
     public void writeAndReadBack() {
-        Request.Invocation emailQuery = new Request.Invocation(new QueryEmailMethodCall("accountId"), METHOD_CALL_ID);
+        Request.Invocation emailQuery = new Request.Invocation(QueryEmailMethodCall.builder().accountId("accountId").build(), METHOD_CALL_ID);
         Request.Invocation.ResultReference resultReferenceOut = emailQuery.createReference("/ids");
         GsonBuilder gsonBuilder = new GsonBuilder();
         ResultReferenceTypeAdapter.register(gsonBuilder);

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/ResultReferenceTypeAdapterTest.java
@@ -13,7 +13,10 @@ public class ResultReferenceTypeAdapterTest {
 
     @Test
     public void writeAndReadBack() {
-        Request.Invocation emailQuery = new Request.Invocation(QueryEmailMethodCall.builder().accountId("accountId").build(), METHOD_CALL_ID);
+        Request.Invocation emailQuery = new Request.Invocation(
+                QueryEmailMethodCall.builder().accountId("accountId").build(),
+                METHOD_CALL_ID
+        );
         Request.Invocation.ResultReference resultReferenceOut = emailQuery.createReference("/ids");
         GsonBuilder gsonBuilder = new GsonBuilder();
         ResultReferenceTypeAdapter.register(gsonBuilder);

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailMethodCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailMethodCallTest.java
@@ -19,7 +19,13 @@ public class SetEmailMethodCallTest extends AbstractGsonTest {
         GsonBuilder builder = new GsonBuilder();
         JmapAdapters.register(builder);
         Gson gson = builder.create();
-        Request request = new Request.Builder().call(new SetEmailMethodCall("accountId", "state", ImmutableMap.of("M123", Patches.remove("keywords/$seen")))).build();
+        Request request = new Request.Builder().call(
+                SetEmailMethodCall.builder()
+                        .accountId("accountId")
+                        .ifInState("state")
+                        .update(ImmutableMap.of("M123", Patches.remove("keywords/$seen")))
+                        .build()
+        ).build();
         Assert.assertEquals(readResourceAsString("request/set-email.json"),gson.toJson(request));
     }
 

--- a/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailSubmissionMethodCallTest.java
+++ b/jmap-gson/src/test/java/rs/ltt/jmap/gson/SetEmailSubmissionMethodCallTest.java
@@ -40,20 +40,24 @@ public class SetEmailSubmissionMethodCallTest extends AbstractGsonTest {
         final Patches.Builder patchesBuilder = Patches.builder();
         patchesBuilder.remove("keywords/" + Keyword.DRAFT);
         patchesBuilder.set("mailboxIds/MB3", true);
-        SetEmailSubmissionMethodCall submissionCall = new SetEmailSubmissionMethodCall(
-                "accountId",
-                ImmutableMap.of(
-                        "es0",
-                        EmailSubmission.builder()
-                                .emailId("M1234")
-                                .identityId("I0")
-                                .build()
-                ),
-                ImmutableMap.of(
-                        "#es0",
-                        patchesBuilder.build()
+        SetEmailSubmissionMethodCall submissionCall = SetEmailSubmissionMethodCall.builder()
+                .accountId("accountId")
+                .create(
+                        ImmutableMap.of(
+                                "es0",
+                                EmailSubmission.builder()
+                                        .emailId("M1234")
+                                        .identityId("I0")
+                                        .build()
+                        )
                 )
-        );
+                .onSuccessUpdateEmail(
+                        ImmutableMap.of(
+                                "#es0",
+                                patchesBuilder.build()
+                        )
+                )
+                .build();
         Request request = new Request.Builder().call(submissionCall).build();
         Assert.assertEquals(readResourceAsString("request/set-email-submission.json"),gson.toJson(request));
     }

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
@@ -34,7 +34,12 @@ import rs.ltt.jmap.common.method.call.thread.GetThreadMethodCall;
 public class UpdateUtil {
 
     public static MethodResponsesFuture emails(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesEmailMethodCall(accountId, state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(
+                ChangesEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .sinceState(state)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetEmailMethodCall(
                 accountId,
@@ -51,7 +56,12 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture identities(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesIdentityMethodCall(accountId, state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(
+                ChangesIdentityMethodCall.builder()
+                        .accountId(accountId)
+                        .sinceState(state)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetIdentityMethodCall(
                 accountId,
@@ -66,7 +76,12 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture mailboxes(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesMailboxMethodCall(accountId, state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(
+                ChangesMailboxMethodCall.builder()
+                        .accountId(accountId)
+                        .sinceState(state)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetMailboxMethodCall(
                 accountId,
@@ -82,7 +97,12 @@ public class UpdateUtil {
     }
 
     public static MethodResponsesFuture threads(JmapClient.MultiCall multiCall, String accountId, String state) {
-        final JmapRequest.Call changesCallInfo = multiCall.call(new ChangesThreadMethodCall(accountId, state));
+        final JmapRequest.Call changesCallInfo = multiCall.call(
+                ChangesThreadMethodCall.builder()
+                        .accountId(accountId)
+                        .sinceState(state)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
         final ListenableFuture<MethodResponses> created = multiCall.call(new GetThreadMethodCall(
                 accountId,

--- a/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
+++ b/jmap-mua-util/src/main/java/rs/ltt/jmap/mua/util/UpdateUtil.java
@@ -41,16 +41,20 @@ public class UpdateUtil {
                         .build()
         );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
-        final ListenableFuture<MethodResponses> created = multiCall.call(new GetEmailMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED),
-                true
-        )).getMethodResponses();
-        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetEmailMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
-                Email.Properties.MUTABLE
-        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(
+                GetEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED))
+                        .fetchTextBodyValues(true)
+                        .build()
+        ).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(
+                GetEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED))
+                        .properties(Email.Properties.MUTABLE)
+                        .build()
+        ).getMethodResponses();
 
         return new MethodResponsesFuture(changes, created, updated);
     }
@@ -63,14 +67,18 @@ public class UpdateUtil {
                         .build()
         );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
-        final ListenableFuture<MethodResponses> created = multiCall.call(new GetIdentityMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
-        )).getMethodResponses();
-        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetIdentityMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
-        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(
+                GetIdentityMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED))
+                        .build()
+        ).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(
+                GetIdentityMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED))
+                        .build()
+        ).getMethodResponses();
 
         return new MethodResponsesFuture(changes, created, updated);
     }
@@ -83,15 +91,19 @@ public class UpdateUtil {
                         .build()
         );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
-        final ListenableFuture<MethodResponses> created = multiCall.call(new GetMailboxMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
-        )).getMethodResponses();
-        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetMailboxMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED),
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED_PROPERTIES)
-        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(
+                GetMailboxMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED))
+                        .build()
+        ).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(
+                GetMailboxMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED))
+                        .propertiesReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED_PROPERTIES))
+                        .build()
+        ).getMethodResponses();
 
         return new MethodResponsesFuture(changes, created, updated);
     }
@@ -104,14 +116,18 @@ public class UpdateUtil {
                         .build()
         );
         final ListenableFuture<MethodResponses> changes = changesCallInfo.getMethodResponses();
-        final ListenableFuture<MethodResponses> created = multiCall.call(new GetThreadMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED)
-        )).getMethodResponses();
-        final ListenableFuture<MethodResponses> updated = multiCall.call(new GetThreadMethodCall(
-                accountId,
-                changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED)
-        )).getMethodResponses();
+        final ListenableFuture<MethodResponses> created = multiCall.call(
+                GetThreadMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.CREATED))
+                        .build()
+        ).getMethodResponses();
+        final ListenableFuture<MethodResponses> updated = multiCall.call(
+                GetThreadMethodCall.builder()
+                        .accountId(accountId)
+                        .idsReference(changesCallInfo.createResultReference(Request.Invocation.ResultReference.Path.UPDATED))
+                        .build()
+        ).getMethodResponses();
 
         return new MethodResponsesFuture(changes, created, updated);
     }

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -1148,7 +1148,12 @@ public class Mua {
     public ListenableFuture<Boolean> emptyTrash(@NonNullDecl IdentifiableMailboxWithRole trash) {
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
         final EmailFilterCondition filter = EmailFilterCondition.builder().inMailbox(trash.getId()).build();
-        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).filter(filter).build());
+        final Call queryCall = multiCall.call(
+                QueryEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .filter(filter)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> setFuture = multiCall.call(new SetEmailMethodCall(accountId, null, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
         multiCall.execute();
         return Futures.transformAsync(setFuture, new AsyncFunction<MethodResponses, Boolean>() {
@@ -1310,7 +1315,14 @@ public class Mua {
             queryRefreshFuture = null;
         }
 
-        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).query(query).anchor(afterEmailId).limit(this.queryPageSize).build());
+        final Call queryCall = multiCall.call(
+                QueryEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .query(query)
+                        .anchor(afterEmailId)
+                        .limit(this.queryPageSize)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final ListenableFuture<MethodResponses> getThreadIdsResponsesFuture = multiCall.call(
                 new GetEmailMethodCall(
@@ -1484,7 +1496,13 @@ public class Mua {
             queryPageSize = this.queryPageSize;
         }
 
-        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).query(query).limit(queryPageSize).build());
+        final Call queryCall = multiCall.call(
+                QueryEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .query(query)
+                        .limit(queryPageSize)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final Call threadIdsCall = multiCall.call(
                 new GetEmailMethodCall(

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -1148,7 +1148,7 @@ public class Mua {
     public ListenableFuture<Boolean> emptyTrash(@NonNullDecl IdentifiableMailboxWithRole trash) {
         final JmapClient.MultiCall multiCall = jmapClient.newMultiCall();
         final EmailFilterCondition filter = EmailFilterCondition.builder().inMailbox(trash.getId()).build();
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, filter));
+        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).filter(filter).build());
         final ListenableFuture<MethodResponses> setFuture = multiCall.call(new SetEmailMethodCall(accountId, null, queryCall.createResultReference(Request.Invocation.ResultReference.Path.IDS))).getMethodResponses();
         multiCall.execute();
         return Futures.transformAsync(setFuture, new AsyncFunction<MethodResponses, Boolean>() {
@@ -1310,7 +1310,7 @@ public class Mua {
             queryRefreshFuture = null;
         }
 
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, query, afterEmailId, this.queryPageSize));
+        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).query(query).anchor(afterEmailId).limit(this.queryPageSize).build());
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final ListenableFuture<MethodResponses> getThreadIdsResponsesFuture = multiCall.call(
                 new GetEmailMethodCall(
@@ -1484,7 +1484,7 @@ public class Mua {
             queryPageSize = this.queryPageSize;
         }
 
-        final Call queryCall = multiCall.call(new QueryEmailMethodCall(accountId, query, queryPageSize));
+        final Call queryCall = multiCall.call(QueryEmailMethodCall.builder().accountId(accountId).query(query).limit(queryPageSize).build());
         final ListenableFuture<MethodResponses> queryResponsesFuture = queryCall.getMethodResponses();
         final Call threadIdsCall = multiCall.call(
                 new GetEmailMethodCall(

--- a/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
+++ b/jmap-mua/src/main/java/rs/ltt/jmap/mua/Mua.java
@@ -1404,7 +1404,14 @@ public class Mua {
 
         final List<ListenableFuture<Status>> piggyBackedFuturesList = piggyBack(queryStateWrapper.objectsState, multiCall);
 
-        final Call queryChangesCall = multiCall.call(new QueryChangesEmailMethodCall(accountId, queryStateWrapper.queryState, query)); //TODO do we want to include upTo?
+        final Call queryChangesCall = multiCall.call(
+                //TODO do we want to include upTo?
+                QueryChangesEmailMethodCall.builder()
+                        .accountId(accountId)
+                        .sinceQueryState(queryStateWrapper.queryState)
+                        .query(query)
+                        .build()
+        );
         final ListenableFuture<MethodResponses> queryChangesResponsesFuture = queryChangesCall.getMethodResponses();
         final ListenableFuture<MethodResponses> getThreadIdResponsesFuture = multiCall.call(
                 new GetEmailMethodCall(


### PR DESCRIPTION
Often there seems to be a desirable constructor missing for classes that implement `MethodCall`. This is a draft to switch to builders for `QueryMethodCall` subclasses. If this is acceptable I can do it for the other `*MethodCall` classes, too.