### PR TITLE
Add serverFail error

### DIFF
--- a/jmap-client/src/main/java/rs/ltt/jmap/client/api/MethodErrorResponseException.java
+++ b/jmap-client/src/main/java/rs/ltt/jmap/client/api/MethodErrorResponseException.java
@@ -20,6 +20,7 @@ import rs.ltt.jmap.common.method.MethodCall;
 import rs.ltt.jmap.common.method.MethodErrorResponse;
 import rs.ltt.jmap.common.method.MethodResponse;
 import rs.ltt.jmap.common.method.error.InvalidArgumentsMethodErrorResponse;
+import rs.ltt.jmap.common.method.error.ServerFailMethodErrorResponse;
 import rs.ltt.jmap.common.util.Mapper;
 
 public class MethodErrorResponseException extends JmapApiException {
@@ -50,14 +51,19 @@ public class MethodErrorResponseException extends JmapApiException {
         }
         messageBuilder.append(" in response to ");
         messageBuilder.append(Mapper.METHOD_CALLS.inverse().get(methodCall.getClass()));
+
+        String description = null;
+
         if (methodErrorResponse instanceof InvalidArgumentsMethodErrorResponse) {
-            final String description =
+            description =
                     ((InvalidArgumentsMethodErrorResponse) methodErrorResponse).getDescription();
-            if (description != null) {
-                messageBuilder.append(" (");
-                messageBuilder.append(description);
-                messageBuilder.append(')');
-            }
+        } else if (methodErrorResponse instanceof ServerFailMethodErrorResponse) {
+            description = ((ServerFailMethodErrorResponse) methodErrorResponse).getDescription();
+        }
+        if (description != null) {
+            messageBuilder.append(" (");
+            messageBuilder.append(description);
+            messageBuilder.append(')');
         }
         return messageBuilder.toString();
     }

--- a/jmap-common/src/main/java/rs/ltt/jmap/common/method/error/ServerFailMethodErrorResponse.java
+++ b/jmap-common/src/main/java/rs/ltt/jmap/common/method/error/ServerFailMethodErrorResponse.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Daniel Gultsch
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package rs.ltt.jmap.common.method.error;
+
+import lombok.Getter;
+import rs.ltt.jmap.annotation.JmapError;
+import rs.ltt.jmap.common.method.MethodErrorResponse;
+
+@JmapError("serverFail")
+@Getter
+public class ServerFailMethodErrorResponse extends MethodErrorResponse {
+
+    private String description;
+}


### PR DESCRIPTION
Adds serverFail (as defined in https://jmap.io/spec-core.html#errors ).

We use that quite a lot to log information about various server errors.